### PR TITLE
Fix Issue with Hidden Labels 

### DIFF
--- a/bar.js
+++ b/bar.js
@@ -73,7 +73,7 @@ H5P.Chart.BarChart = (function () {
           return '#' + d.fontColor;
         }
         // Set default color as black
-        return '#00000';
+        return '#000000';
       });
 
     /**
@@ -89,7 +89,7 @@ H5P.Chart.BarChart = (function () {
       var tickSize = (fontSize * 0.125);
       var height = h - tickSize - lineHeight; // Add space for labels below
 
-      // Update  size
+      // Update SVG size
       svg.attr("width", width)
         .attr("height", h);
 

--- a/bar.js
+++ b/bar.js
@@ -72,7 +72,8 @@ H5P.Chart.BarChart = (function () {
         if (d.fontColor !== undefined) {
           return '#' + d.fontColor;
         }
-        return '#000000';
+        // Set default color as black
+        return '#00000';
       });
 
     /**
@@ -82,13 +83,13 @@ H5P.Chart.BarChart = (function () {
       // Always scale to available space
       var style = window.getComputedStyle($wrapper[0]);
       var width = parseFloat(style.width);
-      var h = parseFloat(style.height);
+      var h = parseFloat(style.height)-20;
       var fontSize = parseFloat(style.fontSize);
       var lineHeight = (1.25 * fontSize);
       var tickSize = (fontSize * 0.125);
       var height = h - tickSize - lineHeight; // Add space for labels below
 
-      // Update SVG size
+      // Update  size
       svg.attr("width", width)
         .attr("height", h);
 
@@ -120,7 +121,7 @@ H5P.Chart.BarChart = (function () {
           return xScale(i) + xScale.rangeBand() / 2;
         })
         .attr("y", function(d) {
-          return height - yScale(d.value) + lineHeight;
+          return height - yScale(d.value) + lineHeight - 20;
         });
     };
   }

--- a/chart.css
+++ b/chart.css
@@ -1,6 +1,7 @@
 .h5p-chart svg {
   display: block;
   margin: 0 auto;
+  padding-top: 20px;
 }
 .h5p-chart-chart {
   font-size: 0.75em;

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 1,
+  "patchVersion": 2,
   "runnable": 1,
   "author": "Joubel AS",
   "license": "MIT",

--- a/semantics.json
+++ b/semantics.json
@@ -44,7 +44,7 @@
           "type": "text",
           "widget": "colorSelector",
           "label": "Color",
-          "default": "000",
+          "default": "red",
           "optional": true
         },
         {

--- a/semantics.json
+++ b/semantics.json
@@ -52,7 +52,7 @@
           "type": "text",
           "widget": "colorSelector",
           "label": "Font Color",
-          "default": "fff",
+          "default": "000",
           "optional": true
         }
       ]


### PR DESCRIPTION
Fixed the following issue:

If the content type Chart is created with data elements having minimum and maximum values, the value-label won’t be clearly visible for the elements with minimum value. This is only a problem for the bar-chart. An example is found here (the red bar should display the number “1”):

https://h5p.org/node/10625/
