### PR TITLE
Add new features created by NDLA/TietoEVRY

### DIFF
--- a/bar.js
+++ b/bar.js
@@ -1,5 +1,5 @@
 /*global d3*/
-H5P.Chart.BarChart = (function () {
+H5P.NDLAChart.BarChart = (function () {
 
   /**
    * Creates a bar chart from the given data set.

--- a/bar.js
+++ b/bar.js
@@ -94,8 +94,7 @@ H5P.Chart.BarChart = (function () {
       var height = h - tickSize - lineHeight; // Add space for labels below
 
       // Update SVG size
-      svg.attr("width", width)
-        .attr("height", h);
+      svg.attr('viewBox', `0 0 ${width} ${h}`);
 
       // Update scales
       xScale.rangeRoundBands([0, width], 0.05);

--- a/bar.js
+++ b/bar.js
@@ -56,7 +56,7 @@ H5P.Chart.BarChart = (function () {
       .data(dataSet, key)
       .enter()
       .append("rect")
-      .attr("fill", function(d) {
+      .attr("fill", function (d) {
         if (d.color !== undefined) {
           return d.color;
         }
@@ -68,7 +68,7 @@ H5P.Chart.BarChart = (function () {
       .data(dataSet, key)
       .enter()
       .append("text")
-      .text(function(d) {
+      .text(function (d) {
         return d.value;
       })
       .attr("text-anchor", "middle")
@@ -108,19 +108,19 @@ H5P.Chart.BarChart = (function () {
         .call(xAxis);
 
       // Move rectangles (bars)
-      rects.attr("x", function(d, i) {
+      rects.attr("x", function (d, i) {
         return xScale(i);
-      }).attr("y", function(d) {
+      }).attr("y", function (d) {
         return height - yScale(d.value);
       }).attr("width", xScale.rangeBand())
-        .attr("height", function(d) {
+        .attr("height", function (d) {
           return yScale(d.value);
         });
 
       // Re-locate text value labels
-      texts.attr("x", function(d, i) {
+      texts.attr("x", function (d, i) {
         return xScale(i) + xScale.rangeBand() / 2;
-      }).attr("y", function(d) {
+      }).attr("y", function (d) {
         return height - yScale(d.value) + lineHeight;
       });
 

--- a/bar.js
+++ b/bar.js
@@ -125,7 +125,7 @@ H5P.Chart.BarChart = (function () {
         return height - yScale(d.value) + lineHeight;
       });
 
-      // Hide ticks from readspeakers, the entire rectangle is already labelled
+      // Hide ticks from screen readers, the entire rectangle is already labelled
       xAxisG.selectAll("text").attr("aria-hidden", true);
     };
   }

--- a/chart.css
+++ b/chart.css
@@ -3,6 +3,8 @@
   margin: 0 auto;
   font-size: 12px;
   font-size: min(16px, 0.9em);
+  width: 100%;
+  height: 100%;
 }
 .h5p-chart-bar {
   width: 100%;

--- a/chart.css
+++ b/chart.css
@@ -31,3 +31,11 @@
   height:1px;
   overflow:hidden;
 }
+
+.y-axis .tick line {
+  stroke: black;
+  opacity: 0.4;
+}
+.y-axis path {
+  stroke-width: 0;
+}

--- a/chart.css
+++ b/chart.css
@@ -32,7 +32,11 @@
   overflow:hidden;
 }
 
-.h5p-chart text {
+.h5p-chart .text-rect {
+  fill: black;
+}
+.h5p-chart .text-rect .text-node {
+  fill: white;
 }
 
 .h5p-chart .line-path {
@@ -50,4 +54,17 @@
 }
 .h5p-chart .y-axis path {
   stroke-width: 0;
+}
+
+div.tooltip {
+  position: absolute;
+  text-align: center;
+  width: 60px;
+  height: 28px;
+  padding: 2px;
+  font: 12px sans-serif;
+  background: lightsteelblue;
+  border: 0px;
+  border-radius: 8px;
+  pointer-events: none;
 }

--- a/chart.css
+++ b/chart.css
@@ -23,7 +23,7 @@
   height: 25em;
 }
 
-.h5p-chart .hidden-but-read {>
+.h5p-chart .hidden-but-read {
   position:absolute;
   left:-10000px;
   top:auto;

--- a/chart.css
+++ b/chart.css
@@ -34,37 +34,39 @@
 
 .h5p-chart .text-rect {
   fill: black;
+  opacity: 0.7;
 }
-.h5p-chart .text-rect .text-node {
+.h5p-chart .text-node {
   fill: white;
+  font-size: 1.2em;
+}
+
+.h5p-chart circle:focus {
+  outline: black 2px solid;
 }
 
 .h5p-chart .line-path {
   fill: none;
-  stroke-width: 1.5px;
+  stroke-width: 2px;
 }
 
 .h5p-chart .chart-title {
   font-size: 1.5em;
+  font-weight: bold;
 }
 
 .h5p-chart .y-axis .tick line {
   stroke: black;
   opacity: 0.4;
 }
+
+.h5p-chart .axis-title {
+  font-size: 1.3em;;
+  font-weight: bold;
+}
+.h5p-chart text {
+  font-size: 1.1em;;
+}
 .h5p-chart .y-axis path {
   stroke-width: 0;
-}
-
-div.tooltip {
-  position: absolute;
-  text-align: center;
-  width: 60px;
-  height: 28px;
-  padding: 2px;
-  font: 12px sans-serif;
-  background: lightsteelblue;
-  border: 0px;
-  border-radius: 8px;
-  pointer-events: none;
 }

--- a/chart.css
+++ b/chart.css
@@ -23,7 +23,7 @@
   height: 25em;
 }
 
-.h5p-chart .hidden-but-read {
+.h5p-chart .hidden-but-read {>
   position:absolute;
   left:-10000px;
   top:auto;

--- a/chart.css
+++ b/chart.css
@@ -1,9 +1,8 @@
 .h5p-chart svg {
   display: block;
   margin: 0 auto;
-}
-.h5p-chart-chart {
-  font-size: 0.75em;
+  font-size: 12px;
+  font-size: min(16px, 0.9em);
 }
 .h5p-chart-bar {
   width: 100%;

--- a/chart.css
+++ b/chart.css
@@ -32,10 +32,17 @@
   overflow:hidden;
 }
 
-.y-axis .tick line {
+.h5p-chart text {
+}
+
+.h5p-chart .chart-title {
+  font-size: 1.5em;
+}
+
+.h5p-chart .y-axis .tick line {
   stroke: black;
   opacity: 0.4;
 }
-.y-axis path {
+.h5p-chart .y-axis path {
   stroke-width: 0;
 }

--- a/chart.css
+++ b/chart.css
@@ -36,10 +36,7 @@
   fill: black;
   opacity: 0.7;
 }
-.h5p-chart .text-node {
-  fill: white;
-  font-size: 1.2em;
-}
+
 
 .h5p-chart circle:focus, .h5p-chart .bar:focus {
   outline: dodgerblue 2px solid;
@@ -66,6 +63,11 @@
 }
 .h5p-chart text {
   font-size: 1.1em;;
+}
+.h5p-chart .text-node {
+  fill: white;
+  font-size: 1.2em;
+  dominant-baseline: central;
 }
 .h5p-chart .y-axis path {
   stroke-width: 0;

--- a/chart.css
+++ b/chart.css
@@ -37,7 +37,6 @@
 
 .h5p-chart .line-path {
   fill: none;
-  stroke: black;
   stroke-width: 1.5px;
 }
 

--- a/chart.css
+++ b/chart.css
@@ -41,8 +41,8 @@
   font-size: 1.2em;
 }
 
-.h5p-chart circle:focus {
-  outline: black 2px solid;
+.h5p-chart circle:focus, .h5p-chart .bar:focus {
+  outline: dodgerblue 2px solid;
 }
 
 .h5p-chart .line-path {

--- a/chart.css
+++ b/chart.css
@@ -35,6 +35,12 @@
 .h5p-chart text {
 }
 
+.h5p-chart .line-path {
+  fill: none;
+  stroke: black;
+  stroke-width: 1.5px;
+}
+
 .h5p-chart .chart-title {
   font-size: 1.5em;
 }

--- a/chart.js
+++ b/chart.js
@@ -124,7 +124,7 @@ H5P.NDLAChart = (function ($, EventDispatcher) {
       self.$wrapper = $('<div/>', {
         'class': 'h5p-chart-chart h5p-chart-' + self.type.toLowerCase()
       });
-      self.chart = new H5P.Chart[self.type + 'Chart'](self.params, self.$wrapper);
+      self.chart = new H5P.NDLAChart[self.type + 'Chart'](self.params, self.$wrapper);
     }
 
     // Prepare container

--- a/chart.js
+++ b/chart.js
@@ -73,7 +73,7 @@ H5P.Chart = (function ($, EventDispatcher) {
       case 'extendedBarChart':
         return 'ExtendedBar';
 
-        case 'lineChart':
+      case 'lineChart':
         return 'Line';
 
       default:
@@ -137,7 +137,7 @@ H5P.Chart = (function ($, EventDispatcher) {
     });
 
     // Add aria-labels for the data
-    self.params.listOfTypes.forEach(function(type) {
+    self.params.listOfTypes.forEach(function (type) {
       var ariaLabel = $('<div/>', {
         'class': 'hidden-but-read',
         'html': type.text + ': ' + type.value + ''

--- a/chart.js
+++ b/chart.js
@@ -22,6 +22,7 @@ H5P.Chart = (function ($, EventDispatcher) {
 
     // Set params and filter data set to make sure it's valid
     self.params = params;
+    console.log(self.params);
     if (self.params.listOfTypes) {
       Chart.filterData(self.params.listOfTypes);
     }
@@ -34,8 +35,8 @@ H5P.Chart = (function ($, EventDispatcher) {
       self.params.listOfTypes = [
         {
           text: 'Cat',
-          value: 1,
-          color: '#D3D3D3',
+          value: 4,
+          color: '#fbb033',
           fontColor: '#000'
         },
         {
@@ -59,9 +60,27 @@ H5P.Chart = (function ($, EventDispatcher) {
     }
 
     // Keep track of type.
-    self.type = (self.params.graphMode === 'pieChart' ? 'Pie' : 'Bar');
+    //self.type = (self.params.graphMode === 'pieChart' ? 'Pie' : 'Bar');
+    self.type = getChartType(self.params.graphMode);
+    console.log("self");
+    console.log(self);
   }
 
+  function getChartType(graphMode) {
+    switch (graphMode) {
+      case 'pieChart':
+        return 'Pie';
+
+      case 'barChart':
+        return 'Bar';
+
+      case 'extendedBarChart':
+        return 'ExtendedBar';
+
+      default:
+        return 'Pie';
+    }
+  }
   // Inheritance
   Chart.prototype = Object.create(EventDispatcher.prototype);
   Chart.prototype.constructor = Chart;

--- a/chart.js
+++ b/chart.js
@@ -53,7 +53,7 @@ H5P.Chart = (function ($, EventDispatcher) {
       ];
     }
 
-    // Set the figure definition for readspeakers if it doesn't exist
+    // Set the figure definition for screen readers if it doesn't exist
     if (!self.params.figureDefinition) {
       self.params.figureDefinition = "Chart";
     }

--- a/chart.js
+++ b/chart.js
@@ -5,7 +5,7 @@
  * @external {jQuery} $ H5P.jQuery
  * @external {EventDispatcher} EventDispatcher H5P.EventDispatcher
  */
-H5P.Chart = (function ($, EventDispatcher) {
+H5P.NDLAChart = (function ($, EventDispatcher) {
 
   /**
    * Initialize module.

--- a/chart.js
+++ b/chart.js
@@ -59,7 +59,6 @@ H5P.Chart = (function ($, EventDispatcher) {
     }
 
     // Keep track of type.
-    //self.type = (self.params.graphMode === 'pieChart' ? 'Pie' : 'Bar');
     self.type = getChartType(self.params.graphMode);
   }
 

--- a/chart.js
+++ b/chart.js
@@ -73,6 +73,9 @@ H5P.Chart = (function ($, EventDispatcher) {
       case 'extendedBarChart':
         return 'ExtendedBar';
 
+        case 'lineChart':
+        return 'Line';
+
       default:
         return 'Pie';
     }

--- a/chart.js
+++ b/chart.js
@@ -22,7 +22,6 @@ H5P.Chart = (function ($, EventDispatcher) {
 
     // Set params and filter data set to make sure it's valid
     self.params = params;
-    console.log(self.params);
     if (self.params.listOfTypes) {
       Chart.filterData(self.params.listOfTypes);
     }
@@ -62,8 +61,6 @@ H5P.Chart = (function ($, EventDispatcher) {
     // Keep track of type.
     //self.type = (self.params.graphMode === 'pieChart' ? 'Pie' : 'Bar');
     self.type = getChartType(self.params.graphMode);
-    console.log("self");
-    console.log(self);
   }
 
   function getChartType(graphMode) {

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -109,14 +109,16 @@ H5P.Chart.ExtendedBarChart = (function () {
         .enter();
 
     // Create inner rect labels
-    var barTexts = svg.selectAll('text')
+    var barTexts = rectGroup
+        .selectAll('text')
         .data(dataSet, key)
         .enter()
         .append('text')
+        .attr('text-anchor', 'middless')
         .text(function(d) {
           return d.value;
         })
-        .attr('text-anchor', 'middle')
+        .attr('text-anchor', 'middless')
         .attr('fill', function (d) {
           if(params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ){
             return params.overrideColorGroup.overrideChartColorText;
@@ -218,16 +220,15 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       var offsetFromBar = 5;
       // Re-locate text value labels
+
       barTexts.attr('x', function(d, i) {
-        if(isYAxisTextDefined) {
-          return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
-        }
-        else {
-          return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
-        }
+          var barTextWidth = this.getBoundingClientRect().width;
+          return xScale(i) + xScale.rangeBand() / 2 - barTextWidth / 2;
+
       }).attr('y', function(d) {
-        return yScale(d.value) + chartTitleTextOffset - offsetFromBar;
+        return yScale(d.value)  - offsetFromBar;
       });
+
 
       // Hide ticks from screen readers, the entire rectangle is already labelled
       xAxisG.selectAll('text').attr('aria-hidden', true);

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -64,6 +64,7 @@ H5P.Chart.ExtendedBarChart = (function () {
     var key = function (d) {
       return dataSet.indexOf(d);
     };
+    //rectGroup is for grouping the bars in
     var rectGroup = svg.append("g")
         .attr("class", "rect-group");
 
@@ -161,20 +162,21 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       xAxis.tickSize([0]);
       xAxisG.call(xAxis);
-      var firstXaxisTick = xAxisG.select('.tick');
-      var firstXaxisTickWidth = firstXaxisTick[0][0].getBoundingClientRect().width;
+
       yAxisG.call(yAxis
           .tickSize(-width, 0, 0)
           .ticks(getSmartTicks(d3.max(dataSet).value).count));
-      //Gets all text element from the Y Axis
+      //Gets first text element from the Y Axis
       var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
-      //Gets width of last Y Axis tick text element
+      //Gets width of last Y Axis tick text elements
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
       var minYAxisGMargin = 20;
 
+      //x translateion differs from when the y axis title text is defined
       const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth + minYAxisGMargin : yAxisLastTickWidth);
 
+      // Y translation used for y axis tick group
       const yTranslation = chartTitleTextOffset;
 
       xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin + xScale.rangeBand()/2}, ${lineHeight/2})`);
@@ -192,27 +194,23 @@ H5P.Chart.ExtendedBarChart = (function () {
           .attr('x', height/2)
           .attr('y', 0);
       var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
-      // Move rectangles (bars)
 
-      //Used for positioning/translating the X axis ticks to be in the middle of each bar
       xAxisGTexts.attr('transform', function(d, i) {
         var x;
         var y = chartTitleTextOffset;
-
-          x = xScale(i)  ;
+          x = xScale(i);
           y += height;
           return  'translate (' + x + ', ' + y +')';
 
       });
+//positioning the rectgroup
+      rectGroup.attr('transform', `translate(${xTranslation + lineHeight}, ${chartTitleTextOffset})`);
 
-      rectGroup.attr('transform', `translate(${xTranslation + lineHeight}, ${0})`);
-
+      //rects are already inside the rectGroup, so we need to position them
       rects.attr('x', function(d, i) {
-        //if Y Axis title is defined lets make space for Y Axis title by adding the lineheight times 2, to each bar position, and the width of the last, and presumably longest, tick text width
           return xScale(i);
       }).attr('y', function(d) {
-        //If chart text is defined, add the height of the svg chart text and the lineheight to offsett the rects on the y
-        return  yScale(d.value) + chartTitleTextOffset;
+        return  yScale(d.value);
       }).attr('width', xScale.rangeBand())
           .attr('height', function(d) {
             return height - yScale(d.value) ;
@@ -221,14 +219,12 @@ H5P.Chart.ExtendedBarChart = (function () {
       // Re-locate text value labels
       texts.attr('x', function(d, i) {
         if(isYAxisTextDefined) {
-          //Offset a bt more if the Y Axis text is defined
           return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
         }
         else {
           return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
         }
       }).attr('y', function(d) {
-        //Add more room with a ternary if chart text is defined
         return height - lineHeight + chartTitleTextOffset;
       });
 

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -109,7 +109,7 @@ H5P.Chart.ExtendedBarChart = (function () {
         .enter();
 
     // Create inner rect labels
-    var texts = svg.selectAll('text')
+    var barTexts = svg.selectAll('text')
         .data(dataSet, key)
         .enter()
         .append('text')
@@ -134,23 +134,25 @@ H5P.Chart.ExtendedBarChart = (function () {
     self.resize = function () {
       // Always scale to available space
       var style = window.getComputedStyle($wrapper[0]);
-      var width = parseFloat(style.width);
-      var h = parseFloat(style.height);
+      var horizontalPadding = Math.max(parseFloat(style.width) / 12, 40);
+      var verticalPadding = Math.max(parseFloat(style.height) / 12, 20);
+      var width = parseFloat(style.width) - horizontalPadding;
+      var h = parseFloat(style.height) - verticalPadding;
       var fontSize = parseFloat(style.fontSize);
       var lineHeight = (1.25 * fontSize);
       var xTickSize = (fontSize * 0.125);
       var xAxisRectOffset = lineHeight * 3;
       //If chart title doesnt exist, we still make an offset
       var chartTitleTextHeight = chartTextDefined ? svg.select('.chart-title')[0][0].getBoundingClientRect().height : 20;
-      var chartTitleTextOffset =  chartTitleTextHeight  + lineHeight; // Takes the height of the text element and adds line height, so we always have som space under the title
+      var chartTitleTextOffset =  chartTitleTextHeight  + lineHeight + verticalPadding; // Takes the height of the text element and adds line height, so we always have som space under the title
       var height = h - xTickSize - (lineHeight * 2) - chartTitleTextOffset; // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
       if(isXAxisTextDefined) {
         height = h - xTickSize - (lineHeight * 4) - chartTitleTextOffset;
       }
       // Update SVG size
-      svg.attr('width', width)
-          .attr('height', h);
+      svg.attr('width', width + horizontalPadding)
+          .attr('height', h + verticalPadding);
 
 
       // Update scales
@@ -196,11 +198,9 @@ H5P.Chart.ExtendedBarChart = (function () {
       var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
 
       xAxisGTexts.attr('transform', function(d, i) {
-        var x;
-        var y = chartTitleTextOffset;
-          x = xScale(i);
-          y += height;
-          return  'translate (' + x + ', ' + y +')';
+        var x = xScale(i);
+        var y = chartTitleTextOffset + height;
+        return  `translate (${x}, ${y})`;
 
       });
 //positioning the rectgroup
@@ -208,7 +208,7 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       //rects are already inside the rectGroup, so we need to position them
       rects.attr('x', function(d, i) {
-          return xScale(i);
+        return xScale(i);
       }).attr('y', function(d) {
         return  yScale(d.value);
       }).attr('width', xScale.rangeBand())
@@ -216,8 +216,9 @@ H5P.Chart.ExtendedBarChart = (function () {
             return height - yScale(d.value) ;
           });
 
+      var offsetFromBar = 5;
       // Re-locate text value labels
-      texts.attr('x', function(d, i) {
+      barTexts.attr('x', function(d, i) {
         if(isYAxisTextDefined) {
           return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
         }
@@ -225,7 +226,7 @@ H5P.Chart.ExtendedBarChart = (function () {
           return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
         }
       }).attr('y', function(d) {
-        return height - lineHeight + chartTitleTextOffset;
+        return yScale(d.value) + chartTitleTextOffset - offsetFromBar;
       });
 
       // Hide ticks from screen readers, the entire rectangle is already labelled

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -1,0 +1,168 @@
+/*global d3*/
+H5P.Chart.ExtendedBarChart = (function () {
+
+  /**
+   * Creates a bar chart from the given data set.
+   *
+   * @class
+   * @param {array} params from semantics, contains data set
+   * @param {H5P.jQuery} $wrapper
+   */
+  function extendedBarChart(params, $wrapper) {
+    var self = this;
+    var dataSet = params.listOfTypes;
+    var defColors = d3.scale.ordinal()
+        .range(["#fbb033", "#2f2f2f", "#FFB6C1", "#B0C4DE", "#D3D3D3", "#20B2AA", "#FAFAD2"]);
+
+    //Lets check if the axes titles are defined, used for setting correct offset for title space in the generated svg
+    var isXAxisDefined = !!params.xAxisText;
+    var isYAxisDefined = !!params.yAxisText;
+
+    // Create scales for bars
+    var xScale = d3.scale.ordinal()
+        .domain(d3.range(dataSet.length));
+
+    var yScale = d3.scale.linear()
+        .domain([0, d3.max(dataSet, function (d) {
+          return d.value;
+        })]);
+
+    var x = d3.time.scale();
+    var y = d3.scale.linear();
+
+    var xAxis = d3.svg.axis()
+        .scale(xScale)
+        .orient("bottom")
+        .tickFormat(function (d) {
+          return dataSet[d % dataSet.length].text;
+        });
+
+    // Create SVG element
+    var svg = d3.select($wrapper[0])
+        .append("svg");
+
+    svg.append("desc").html("chart");
+
+    // Create x axis
+    var xAxisG = svg.append("g")
+        .attr("class", "x-axis");
+
+    /**
+     * @private
+     */
+    var key = function (d) {
+      return dataSet.indexOf(d);
+    };
+
+    // Create rectangles for bars
+    var rects = svg.selectAll("rect")
+        .data(dataSet, key)
+        .enter()
+        .append("rect")
+        .attr("fill", function(d) {
+          if (d.color !== undefined) {
+            return d.color;
+          }
+          return defColors(dataSet.indexOf(d) % 7);
+        });
+
+    var xAxisTitle = svg.append("text")
+        .style("text-anchor", "middle")
+        .text(params.xAxisText);
+
+    var yAxisTitle = svg.append("text")
+        .style("transform", "rotate(90deg)")
+        .text(params.AxisText);
+
+    // Create labels
+    var texts = svg.selectAll("text")
+        .data(dataSet, key)
+        .enter()
+        .append("text")
+        .text(function(d) {
+          return d.value;
+        })
+        .attr("text-anchor", "middle")
+        .attr("fill", function (d) {
+          if (d.fontColor !== undefined) {
+            return d.fontColor;
+          }
+          return '000000';
+        })
+        .attr("aria-hidden", true);
+
+    /**
+     * Fit the current bar chart to the size of the wrapper.
+     */
+    self.resize = function () {
+      // Always scale to available space
+      var style = window.getComputedStyle($wrapper[0]);
+      var width = parseFloat(style.width);
+      var h = parseFloat(style.height);
+      var fontSize = parseFloat(style.fontSize);
+      var lineHeight = (1.25 * fontSize);
+      var tickSize = (fontSize * 0.125);
+
+      var height = h - tickSize - (lineHeight); // Add space for labels below
+
+      //if xAxisTitle exists, them make room for it by adding more lineheight
+      if(isXAxisDefined) {
+      height = h - tickSize - (lineHeight * 2);
+      }
+
+      // Update SVG size
+      svg.attr("width", width)
+          .attr("height", h);
+
+      // Update scales
+      xScale.rangeRoundBands([0, width], 0.05);
+      yScale.range([0, height]);
+
+      x.range([0, width]);
+      y.range([height, 0]);
+
+      xAxis.tickSize([tickSize]);
+      isYAxisDefined ?
+      //Making space for Y Axis title by adding the lineheight to underline
+      xAxisG.attr("transform", "translate("+ lineHeight + "," + height + ")").call(xAxis) :
+          xAxisG.attr("transform", "translate(0," + height + ")").call(xAxis);
+
+
+      // Move rectangles (bars)
+      rects.attr("x", function(d, i) {
+        //if Y Axis title is defined lets make space for Y Axis title by adding the lineheight to each bar position
+        if(isYAxisDefined) {
+        return xScale(i) + lineHeight;
+        } else {
+          return xScale(i);
+        }
+      }).attr("y", function(d) {
+        return height - yScale(d.value);
+      }).attr("width", xScale.rangeBand())
+          .attr("height", function(d) {
+            return yScale(d.value);
+          });
+
+      //Sets the axes titles on resize
+      xAxisTitle
+          .attr("x", width/2 )
+          .attr("y", h);
+      yAxisTitle
+          .attr("x", height/2)
+          .attr("y", 0);
+      console.log(params);
+      // Re-locate text value labels
+      texts.attr("x", function(d, i) {
+        return xScale(i) + xScale.rangeBand() / 2;
+      }).attr("y", function(d) {
+        return height - yScale(d.value) + lineHeight;
+      });
+
+
+      // Hide ticks from readspeakers, the entire rectangle is already labelled
+      xAxisG.selectAll("text").attr("aria-hidden", true);
+    };
+  }
+
+  return extendedBarChart;
+})();

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -1,5 +1,5 @@
 /*global d3*/
-H5P.Chart.ExtendedBarChart = (function () {
+H5P.NDLAChart.ExtendedBarChart = (function () {
 
   /**
    * Creates a bar chart from the given data set.

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -173,13 +173,13 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       var minYAxisGMargin = 20;
 
-      const yAxisXTranslation = (isYAxisTextDefined ? yAxisLastTickWidth + minYAxisGMargin : yAxisLastTickWidth);
+      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth + minYAxisGMargin : yAxisLastTickWidth);
 
       const yTranslation = chartTitleTextOffset;
 
-      xAxisG.attr('transform', `translate(${yAxisXTranslation + minYAxisGMargin + xScale.rangeBand()/2}, ${lineHeight/2})`);
+      xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin + xScale.rangeBand()/2}, ${lineHeight/2})`);
       yAxisG
-          .attr('transform', `translate(${yAxisXTranslation + lineHeight}, ${yTranslation})`);
+          .attr('transform', `translate(${xTranslation + lineHeight}, ${yTranslation})`);
       //Sets the axes titles on resize
       chartText
           .attr('x', width/2 )
@@ -205,7 +205,7 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       });
 
-      rectGroup.attr('transform', `translate(${yAxisXTranslation + lineHeight}, ${0})`);
+      rectGroup.attr('transform', `translate(${xTranslation + lineHeight}, ${0})`);
 
       rects.attr('x', function(d, i) {
         //if Y Axis title is defined lets make space for Y Axis title by adding the lineheight times 2, to each bar position, and the width of the last, and presumably longest, tick text width

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -47,7 +47,8 @@ H5P.Chart.ExtendedBarChart = (function () {
 
     // Create x axis
     var xAxisG = svg.append("g")
-        .attr("class", "x-axis")
+        .attr("class", "x-axis");
+
     var yAxisG = svg.append("g")
         .attr("class", "y-axis")
         .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ')');
@@ -173,8 +174,6 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       var xAxisGTexts = svg.selectAll("g.x-axis g.tick");
 
-      console.log(xAxisGTexts);
-
       xAxisGTexts.attr("transform", function(d, i) {
         var x;
         var y;
@@ -202,7 +201,6 @@ H5P.Chart.ExtendedBarChart = (function () {
         return height - lineHeight;
       });
 
-      console.log(self)
       // Hide ticks from readspeakers, the entire rectangle is already labelled
       xAxisG.selectAll("text").attr("aria-hidden", true);
     };

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -15,8 +15,8 @@ H5P.Chart.ExtendedBarChart = (function () {
         .range(["#fbb033", "#2f2f2f", "#FFB6C1", "#B0C4DE", "#D3D3D3", "#20B2AA", "#FAFAD2"]);
 
     //Lets check if the axes titles are defined, used for setting correct offset for title space in the generated svg
-    var isXAxisDefined = !!params.xAxisText;
-    var isYAxisDefined = !!params.yAxisText;
+    var isXAxisTextDefined = !!params.xAxisText;
+    var isYAxisTextDefined = !!params.yAxisText;
 
     // Create scales for bars
     var xScale = d3.scale.ordinal()
@@ -24,9 +24,8 @@ H5P.Chart.ExtendedBarChart = (function () {
 
     var yScale = d3.scale.linear()
         .domain([0, d3.max(dataSet, function (d) {
-          return d.value;
+          return d.value ;
         })]);
-
     var x = d3.time.scale();
     var y = d3.scale.linear();
 
@@ -37,6 +36,9 @@ H5P.Chart.ExtendedBarChart = (function () {
           return dataSet[d % dataSet.length].text;
         });
 
+    var yAxis = d3.svg.axis()
+        .scale(yScale)
+        .orient("left");
     // Create SVG element
     var svg = d3.select($wrapper[0])
         .append("svg");
@@ -45,7 +47,11 @@ H5P.Chart.ExtendedBarChart = (function () {
 
     // Create x axis
     var xAxisG = svg.append("g")
-        .attr("class", "x-axis");
+        .attr("class", "x-axis")
+    var yAxisG = svg.append("g")
+        .attr("class", "y-axis")
+        .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ')');
+
 
     /**
      * @private
@@ -72,9 +78,14 @@ H5P.Chart.ExtendedBarChart = (function () {
 
     var yAxisTitle = svg.append("text")
         .style("transform", "rotate(90deg)")
-        .text(params.AxisText);
+        .text(params.yAxisText);
 
-    // Create labels
+    // Create inner rect labels
+    var xAxisGTexts = svg.selectAll("x-axis text")
+        .data(dataSet, key)
+        .enter();
+
+    // Create inner rect labels
     var texts = svg.selectAll("text")
         .data(dataSet, key)
         .enter()
@@ -101,13 +112,12 @@ H5P.Chart.ExtendedBarChart = (function () {
       var h = parseFloat(style.height);
       var fontSize = parseFloat(style.fontSize);
       var lineHeight = (1.25 * fontSize);
-      var tickSize = (fontSize * 0.125);
-
-      var height = h - tickSize - (lineHeight); // Add space for labels below
-
+      var xTickSize = (fontSize * 0.125);
+      var height = h - xTickSize - (lineHeight); // Add space for labels below
+      var xAxisRectOffset = lineHeight * 3;
       //if xAxisTitle exists, them make room for it by adding more lineheight
-      if(isXAxisDefined) {
-      height = h - tickSize - (lineHeight * 2);
+      if(isXAxisTextDefined) {
+        height = h - xTickSize - (lineHeight * 2) ;
       }
 
       // Update SVG size
@@ -115,53 +125,110 @@ H5P.Chart.ExtendedBarChart = (function () {
           .attr("height", h);
 
       // Update scales
-      xScale.rangeRoundBands([0, width], 0.05);
-      yScale.range([0, height]);
+      xScale.rangeRoundBands([0, width - xAxisRectOffset], 0.05);
+      yScale.range([height, 0]);
 
       x.range([0, width]);
       y.range([height, 0]);
+      xAxis.tickSize([0]);
+      xAxisG.attr("transform", "translate(0,0)").call(xAxis);
+      /* isYAxisTextDefined ?
+           //Making space for Y Axis title by adding the lineheight to underline
+           xAxisG.attr("transform", "translate("+ lineHeight * 4 + "," + height + ")").call(xAxis) :
+           xAxisG.attr("transform", "translate(" + lineHeight * 2 + "," + height + ")").call(xAxis);
+ */
 
-      xAxis.tickSize([tickSize]);
-      isYAxisDefined ?
-      //Making space for Y Axis title by adding the lineheight to underline
-      xAxisG.attr("transform", "translate("+ lineHeight + "," + height + ")").call(xAxis) :
-          xAxisG.attr("transform", "translate(0," + height + ")").call(xAxis);
+      yAxisG.call(yAxis
+          .tickSize(-width, 0, 0)
+          .ticks(getSmartTicks(d3.max(dataSet).value).count));
 
-
+      //Gets all text element from the Y Axis
+      var yAxisTicksText = yAxisG.selectAll("g.tick text")[0];
+      //Gets width of last Y Axis tick text element
+      var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
       // Move rectangles (bars)
       rects.attr("x", function(d, i) {
-        //if Y Axis title is defined lets make space for Y Axis title by adding the lineheight to each bar position
-        if(isYAxisDefined) {
-        return xScale(i) + lineHeight;
+        //if Y Axis title is defined lets make space for Y Axis title by adding the lineheight times 2, to each bar position, and the width of the last, and presumably longest, tick text width
+        if(isYAxisTextDefined) {
+          return xScale(i) + xAxisRectOffset + yAxisLastTickWidth;
         } else {
-          return xScale(i);
+          return xScale(i) + lineHeight + yAxisLastTickWidth;
         }
       }).attr("y", function(d) {
-        return height - yScale(d.value);
+        return yScale(d.value);
       }).attr("width", xScale.rangeBand())
           .attr("height", function(d) {
-            return yScale(d.value);
+            return height - yScale(d.value) ;
           });
 
+
       //Sets the axes titles on resize
+
       xAxisTitle
           .attr("x", width/2 )
           .attr("y", h);
       yAxisTitle
           .attr("x", height/2)
           .attr("y", 0);
-      console.log(params);
-      // Re-locate text value labels
-      texts.attr("x", function(d, i) {
-        return xScale(i) + xScale.rangeBand() / 2;
-      }).attr("y", function(d) {
-        return height - yScale(d.value) + lineHeight;
+
+      var xAxisGTexts = svg.selectAll("g.x-axis g.tick");
+
+      console.log(xAxisGTexts);
+
+      xAxisGTexts.attr("transform", function(d, i) {
+        var x;
+        var y;
+        if(isYAxisTextDefined) {
+          x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
+          y = height ;
+          return  "translate (" + x + ", " + y +")";
+        }
+        else {
+          x =  xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
+          y = height ;
+          return  "translate (" + x + ", " + y +")";
+        }
       });
 
 
+      // Re-locate text value labels
+      texts.attr("x", function(d, i) {
+        if(isYAxisTextDefined) {
+          return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth; }
+        else {
+          return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
+        }
+      }).attr("y", function(d) {
+        return height - lineHeight;
+      });
+
+      console.log(self)
       // Hide ticks from readspeakers, the entire rectangle is already labelled
       xAxisG.selectAll("text").attr("aria-hidden", true);
     };
+  }
+
+  function getSmartTicks(val) {
+
+    //base step between nearby two ticks
+    var step = Math.pow(10, val.toString().length - 1);
+
+    //modify steps either: 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000...
+    if (val / step < 2) {
+      step = step / 5;
+    } else if (val / step < 5) {
+      step = step / 2;
+    }
+
+    //add one more step if the last tick value is the same as the max value
+    //if you don't want to add, remove "+1"
+    var slicesCount = Math.ceil((val + 1) / step);
+
+    return {
+      endPoint: slicesCount * step,
+      count: Math.min(10, slicesCount) //show max 10 ticks
+    };
+
   }
 
   return extendedBarChart;

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -153,9 +153,7 @@ H5P.Chart.ExtendedBarChart = (function () {
         height = h - xTickSize - (lineHeight * 4) - chartTitleTextOffset;
       }
       // Update SVG size
-      svg.attr('width', width + horizontalPadding)
-          .attr('height', h + verticalPadding);
-
+      svg.attr('viewBox', `0 0 ${width + horizontalPadding} ${h + verticalPadding}`);
 
       // Update scales
       xScale.rangeRoundBands([0, width - xAxisRectOffset], 0.05); //In order for the X scale to NOT overlap Y axis ticks, we define and offset, making the X scale start further away from the svg wrapper edge

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -13,7 +13,7 @@ H5P.Chart.ExtendedBarChart = (function () {
     var self = this;
     var dataSet = params.listOfTypes;
     var defColors = d3.scale.ordinal()
-        .range(['#fbb033', '#2f2f2f', '#FFB6C1', '#B0C4DE', '#D3D3D3', '#20B2AA', '#FAFAD2']);
+      .range(['#fbb033', '#2f2f2f', '#FFB6C1', '#B0C4DE', '#D3D3D3', '#20B2AA', '#FAFAD2']);
 
     //Lets check if the axes titles are defined, used for setting correct offset for title space in the generated svg
     var chartTextDefined = !!params.chartText;
@@ -25,38 +25,38 @@ H5P.Chart.ExtendedBarChart = (function () {
     var ariaYaxisText = isYAxisTextDefined ? params.yAxisText : "";
     // Create scales for bars
     var xScale = d3.scale.ordinal()
-        .domain(d3.range(dataSet.length));
+      .domain(d3.range(dataSet.length));
 
     var yScale = d3.scale.linear()
-        .domain([0, d3.max(dataSet, function (d) {
-          return d.value ;
-        })]);
+      .domain([0, d3.max(dataSet, function (d) {
+        return d.value ;
+      })]);
     var x = d3.time.scale();
     var y = d3.scale.linear();
 
     var xAxis = d3.svg.axis()
-        .scale(xScale)
-        .orient('bottom')
-        .tickFormat(function (d) {
-          return dataSet[d % dataSet.length].text;
-        });
+      .scale(xScale)
+      .orient('bottom')
+      .tickFormat(function (d) {
+        return dataSet[d % dataSet.length].text;
+      });
 
     var yAxis = d3.svg.axis()
-        .scale(yScale)
-        .orient('left');
+      .scale(yScale)
+      .orient('left');
     // Create SVG element
     var svg = d3.select($wrapper[0])
-        .append('svg');
+      .append('svg');
 
     svg.append('desc').html('chart');
     svg.attr("aria-label", "Bar chart, title: " + ariaChartText +
         ", X axis title: " + ariaXaxisText + ", Y axis text: " + ariaYaxisText);
     // Create x axis
     var xAxisG = svg.append('g')
-        .attr('class', 'x-axis');
+      .attr('class', 'x-axis');
 
     var yAxisG = svg.append('g')
-        .attr('class', 'y-axis')
+      .attr('class', 'y-axis');
 
     /**
      * @private
@@ -66,69 +66,69 @@ H5P.Chart.ExtendedBarChart = (function () {
     };
     //rectGroup is for grouping the bars in
     var rectGroup = svg.append("g")
-        .attr("class", "rect-group");
+      .attr("class", "rect-group");
 
     // Create rectangles for bars
     var rects = rectGroup.selectAll('rect')
-        .data(dataSet, key)
-        .enter()
-        .append('rect')
-        .attr("tabindex", 0)
-        .attr('focusable', 'true')
-        .attr('class', 'bar')
-        .attr("aria-label", (data) => "Y axis: " +  ariaYaxisText + ": " + data.value +
+      .data(dataSet, key)
+      .enter()
+      .append('rect')
+      .attr("tabindex", 0)
+      .attr('focusable', 'true')
+      .attr('class', 'bar')
+      .attr("aria-label", (data) => "Y axis: " +  ariaYaxisText + ": " + data.value +
             ", X axis: " + ariaXaxisText + ": " + data.text)
-        .attr('fill', function(d) {
-          if(params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ){
-            return params.overrideColorGroup.overrideChartColor;
-          }
-          if (d.color !== undefined) {
-            return d.color;
-          }
-          return defColors(dataSet.indexOf(d) % 7);
-        });
+      .attr('fill', function (d) {
+        if (params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ) {
+          return params.overrideColorGroup.overrideChartColor;
+        }
+        if (d.color !== undefined) {
+          return d.color;
+        }
+        return defColors(dataSet.indexOf(d) % 7);
+      });
 
     var chartText = svg.append('text')
-        .style('text-anchor', 'middle')
-        .attr('class', 'chart-title')
-        .text(params.chartText);
+      .style('text-anchor', 'middle')
+      .attr('class', 'chart-title')
+      .text(params.chartText);
 
     var xAxisTitle = svg.append('text')
-        .style('text-anchor', 'middle')
-        .attr('class', 'axis-title')
-        .text(params.xAxisText);
+      .style('text-anchor', 'middle')
+      .attr('class', 'axis-title')
+      .text(params.xAxisText);
 
     var yAxisTitle = svg.append('text')
-        .style('transform', 'rotate(90deg)')
-        .attr('class', 'axis-title')
-        .text(params.yAxisText);
+      .style('transform', 'rotate(90deg)')
+      .attr('class', 'axis-title')
+      .text(params.yAxisText);
 
     // Create inner rect labels
     var xAxisGTexts = svg.selectAll('x-axis text')
-        .data(dataSet, key)
-        .enter();
+      .data(dataSet, key)
+      .enter();
 
     // Create inner rect labels
     var barTexts = rectGroup
-        .selectAll('text')
-        .data(dataSet, key)
-        .enter()
-        .append('text')
-        .attr('text-anchor', 'middless')
-        .text(function(d) {
-          return d.value;
-        })
-        .attr('text-anchor', 'middless')
-        .attr('fill', function (d) {
-          if(params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ){
-            return params.overrideColorGroup.overrideChartColorText;
-          }
-          if (d.fontColor !== undefined) {
-            return d.fontColor;
-          }
-          return '000000';
-        })
-        .attr('aria-hidden', true);
+      .selectAll('text')
+      .data(dataSet, key)
+      .enter()
+      .append('text')
+      .attr('text-anchor', 'middless')
+      .text(function (d) {
+        return d.value;
+      })
+      .attr('text-anchor', 'middless')
+      .attr('fill', function (d) {
+        if (params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ) {
+          return params.overrideColorGroup.overrideChartColorText;
+        }
+        if (d.fontColor !== undefined) {
+          return d.fontColor;
+        }
+        return '000000';
+      })
+      .attr('aria-hidden', true);
 
     /**
      * Fit the current bar chart to the size of the wrapper.
@@ -149,7 +149,7 @@ H5P.Chart.ExtendedBarChart = (function () {
       var chartTitleTextOffset =  chartTitleTextHeight  + lineHeight + verticalPadding; // Takes the height of the text element and adds line height, so we always have som space under the title
       var height = h - xTickSize - (lineHeight * 2) - chartTitleTextOffset; // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
-      if(isXAxisTextDefined) {
+      if (isXAxisTextDefined) {
         height = h - xTickSize - (lineHeight * 4) - chartTitleTextOffset;
       }
       // Update SVG size
@@ -166,8 +166,8 @@ H5P.Chart.ExtendedBarChart = (function () {
       xAxisG.call(xAxis);
 
       yAxisG.call(yAxis
-          .tickSize(-width, 0, 0)
-          .ticks(getSmartTicks(d3.max(dataSet).value).count));
+        .tickSize(-width, 0, 0)
+        .ticks(getSmartTicks(d3.max(dataSet).value).count));
       //Gets first text element from the Y Axis
       var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
       //Gets width of last Y Axis tick text elements
@@ -183,47 +183,47 @@ H5P.Chart.ExtendedBarChart = (function () {
 
       xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin + xScale.rangeBand()/2}, ${lineHeight/2})`);
       yAxisG
-          .attr('transform', `translate(${xTranslation + lineHeight}, ${yTranslation})`);
+        .attr('transform', `translate(${xTranslation + lineHeight}, ${yTranslation})`);
       //Sets the axes titles on resize
       chartText
-          .attr('x', width/2 )
-          .attr('y', lineHeight);
+        .attr('x', width/2 )
+        .attr('y', lineHeight);
 
       xAxisTitle
-          .attr('x', width/2 )
-          .attr('y', h-2);
+        .attr('x', width/2 )
+        .attr('y', h-2);
       yAxisTitle
-          .attr('x', height/2)
-          .attr('y', 0);
+        .attr('x', height/2)
+        .attr('y', 0);
       var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
 
-      xAxisGTexts.attr('transform', function(d, i) {
+      xAxisGTexts.attr('transform', function (d, i) {
         var x = xScale(i);
         var y = chartTitleTextOffset + height;
         return  `translate (${x}, ${y})`;
 
       });
-//positioning the rectgroup
+      //positioning the rectgroup
       rectGroup.attr('transform', `translate(${xTranslation + lineHeight}, ${chartTitleTextOffset})`);
 
       //rects are already inside the rectGroup, so we need to position them
-      rects.attr('x', function(d, i) {
+      rects.attr('x', function (d, i) {
         return xScale(i);
-      }).attr('y', function(d) {
+      }).attr('y', function (d) {
         return  yScale(d.value);
       }).attr('width', xScale.rangeBand())
-          .attr('height', function(d) {
-            return height - yScale(d.value) ;
-          });
+        .attr('height', function (d) {
+          return height - yScale(d.value) ;
+        });
 
       var offsetFromBar = 5;
       // Re-locate text value labels
 
-      barTexts.attr('x', function(d, i) {
-          var barTextWidth = this.getBoundingClientRect().width;
-          return xScale(i) + xScale.rangeBand() / 2 - barTextWidth / 2;
+      barTexts.attr('x', function (d, i) {
+        var barTextWidth = this.getBoundingClientRect().width;
+        return xScale(i) + xScale.rangeBand() / 2 - barTextWidth / 2;
 
-      }).attr('y', function(d) {
+      }).attr('y', function (d) {
         return yScale(d.value)  - offsetFromBar;
       });
 
@@ -246,7 +246,8 @@ H5P.Chart.ExtendedBarChart = (function () {
     //modify steps either: 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000...
     if (val / step < 2) {
       step = step / 5;
-    } else if (val / step < 5) {
+    }
+    else if (val / step < 5) {
       step = step / 2;
     }
 

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -6,7 +6,7 @@ H5P.Chart.ExtendedBarChart = (function () {
    *
    * Notice: ExtendedBar uses its own listOfTypes in h5p-chart/semantics.json, its differentiated through the use of "showWhen"-widget
    * @class
-   * @param {array} params from semantics, contains data set
+   * @param {Object} params from semantics, contains data set
    * @param {H5P.jQuery} $wrapper
    */
   function extendedBarChart(params, $wrapper) {
@@ -218,7 +218,7 @@ H5P.Chart.ExtendedBarChart = (function () {
         return height - lineHeight + (chartTextDefined ? chartTitleTextOffset : 0);
       });
 
-      // Hide ticks from readspeakers, the entire rectangle is already labelled
+      // Hide ticks from screen readers, the entire rectangle is already labelled
       xAxisG.selectAll('text').attr('aria-hidden', true);
     };
   }

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -4,6 +4,7 @@ H5P.Chart.ExtendedBarChart = (function () {
   /**
    * Creates a bar chart from the given data set.
    *
+   * Notice: ExtendedBar uses its own listOfTypes in h5p-chart/semantics.json, its differentiated through the use of "showWhen"-widget
    * @class
    * @param {array} params from semantics, contains data set
    * @param {H5P.jQuery} $wrapper
@@ -59,13 +60,15 @@ H5P.Chart.ExtendedBarChart = (function () {
     var key = function (d) {
       return dataSet.indexOf(d);
     };
-
     // Create rectangles for bars
     var rects = svg.selectAll('rect')
         .data(dataSet, key)
         .enter()
         .append('rect')
         .attr('fill', function(d) {
+          if(params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ){
+            return params.overrideColorGroup.overrideChartColor;
+          }
           if (d.color !== undefined) {
             return d.color;
           }
@@ -100,6 +103,9 @@ H5P.Chart.ExtendedBarChart = (function () {
         })
         .attr('text-anchor', 'middle')
         .attr('fill', function (d) {
+          if(params.overrideColorGroup && params.overrideColorGroup.overrideChartColorsTick ){
+            return params.overrideColorGroup.overrideChartColorText;
+          }
           if (d.fontColor !== undefined) {
             return d.fontColor;
           }

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -176,9 +176,9 @@ H5P.Chart.ExtendedBarChart = (function () {
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
       var minYAxisGMargin = 20;
-
+      var yAxisTitleWidth = yAxisTitle[0][0].getBoundingClientRect().width;
       //x translateion differs from when the y axis title text is defined
-      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth + minYAxisGMargin : yAxisLastTickWidth);
+      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth + yAxisTitleWidth + minYAxisGMargin : yAxisLastTickWidth);
 
       // Y translation used for y axis tick group
       const yTranslation = chartTitleTextOffset;

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -12,7 +12,7 @@ H5P.Chart.ExtendedBarChart = (function () {
     var self = this;
     var dataSet = params.listOfTypes;
     var defColors = d3.scale.ordinal()
-        .range(["#fbb033", "#2f2f2f", "#FFB6C1", "#B0C4DE", "#D3D3D3", "#20B2AA", "#FAFAD2"]);
+        .range(['#fbb033', '#2f2f2f', '#FFB6C1', '#B0C4DE', '#D3D3D3', '#20B2AA', '#FAFAD2']);
 
     //Lets check if the axes titles are defined, used for setting correct offset for title space in the generated svg
     var chartTextDefined = !!params.chartText;
@@ -32,26 +32,26 @@ H5P.Chart.ExtendedBarChart = (function () {
 
     var xAxis = d3.svg.axis()
         .scale(xScale)
-        .orient("bottom")
+        .orient('bottom')
         .tickFormat(function (d) {
           return dataSet[d % dataSet.length].text;
         });
 
     var yAxis = d3.svg.axis()
         .scale(yScale)
-        .orient("left");
+        .orient('left');
     // Create SVG element
     var svg = d3.select($wrapper[0])
-        .append("svg");
+        .append('svg');
 
-    svg.append("desc").html("chart");
+    svg.append('desc').html('chart');
 
     // Create x axis
-    var xAxisG = svg.append("g")
-        .attr("class", "x-axis");
+    var xAxisG = svg.append('g')
+        .attr('class', 'x-axis');
 
-    var yAxisG = svg.append("g")
-        .attr("class", "y-axis")
+    var yAxisG = svg.append('g')
+        .attr('class', 'y-axis')
 
     /**
      * @private
@@ -61,51 +61,51 @@ H5P.Chart.ExtendedBarChart = (function () {
     };
 
     // Create rectangles for bars
-    var rects = svg.selectAll("rect")
+    var rects = svg.selectAll('rect')
         .data(dataSet, key)
         .enter()
-        .append("rect")
-        .attr("fill", function(d) {
+        .append('rect')
+        .attr('fill', function(d) {
           if (d.color !== undefined) {
             return d.color;
           }
           return defColors(dataSet.indexOf(d) % 7);
         });
 
-    var chartText = svg.append("text")
-        .style("text-anchor", "middle")
-        .attr("class", "chart-title")
+    var chartText = svg.append('text')
+        .style('text-anchor', 'middle')
+        .attr('class', 'chart-title')
         .text(params.chartText);
 
-    var xAxisTitle = svg.append("text")
-        .style("text-anchor", "middle")
+    var xAxisTitle = svg.append('text')
+        .style('text-anchor', 'middle')
         .text(params.xAxisText);
 
-    var yAxisTitle = svg.append("text")
-        .style("transform", "rotate(90deg)")
+    var yAxisTitle = svg.append('text')
+        .style('transform', 'rotate(90deg)')
         .text(params.yAxisText);
 
     // Create inner rect labels
-    var xAxisGTexts = svg.selectAll("x-axis text")
+    var xAxisGTexts = svg.selectAll('x-axis text')
         .data(dataSet, key)
         .enter();
 
     // Create inner rect labels
-    var texts = svg.selectAll("text")
+    var texts = svg.selectAll('text')
         .data(dataSet, key)
         .enter()
-        .append("text")
+        .append('text')
         .text(function(d) {
           return d.value;
         })
-        .attr("text-anchor", "middle")
-        .attr("fill", function (d) {
+        .attr('text-anchor', 'middle')
+        .attr('fill', function (d) {
           if (d.fontColor !== undefined) {
             return d.fontColor;
           }
           return '000000';
         })
-        .attr("aria-hidden", true);
+        .attr('aria-hidden', true);
 
     /**
      * Fit the current bar chart to the size of the wrapper.
@@ -119,7 +119,7 @@ H5P.Chart.ExtendedBarChart = (function () {
       var lineHeight = (1.25 * fontSize);
       var xTickSize = (fontSize * 0.125);
       var xAxisRectOffset = lineHeight * 3;
-      var chartTitleTextHeight = svg.select(".chart-title")[0][0].getBoundingClientRect().height;
+      var chartTitleTextHeight = svg.select('.chart-title')[0][0].getBoundingClientRect().height;
       var chartTitleTextOffset =  chartTitleTextHeight + lineHeight; // Takes the height of the text element and adds line height, so we always have som space under the title
       var height = h - xTickSize - (lineHeight) - (chartTextDefined ? chartTitleTextOffset : 0); // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
@@ -128,17 +128,17 @@ H5P.Chart.ExtendedBarChart = (function () {
       }
 
       // Update SVG size
-      svg.attr("width", width)
-          .attr("height", h);
+      svg.attr('width', width)
+          .attr('height', h);
 
       // Update scales
       xScale.rangeRoundBands([0, width - xAxisRectOffset], 0.05); //In order for the X scale to NOT overlap Y axis ticks, we define and offset, making the X scale start further away from the svg wrapper edge
-      yScale.range([height, 0]); //Unlike in 'bar.js', we have "flipped" the chart, making origo to be in top left corner of chart. This is due to the nature of the Y axis ticks
+      yScale.range([height, 0]); //Unlike in 'bar.js', we have 'flipped' the chart, making origo to be in top left corner of chart. This is due to the nature of the Y axis ticks
 
       x.range([0, width]);
       y.range([height, 0]);
       xAxis.tickSize([0]);
-      xAxisG.attr("transform", "translate(0,0)").call(xAxis);
+      xAxisG.attr('transform', 'translate(0,0)').call(xAxis);
       //A lot of conditional moving here. If Y axis text is defined, we translate 40 px in the X direction. In the Y direction we translate downward the by current chartTitle height and line height
       yAxisG
           .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
@@ -148,72 +148,72 @@ H5P.Chart.ExtendedBarChart = (function () {
           .ticks(getSmartTicks(d3.max(dataSet).value).count));
 
       //Gets all text element from the Y Axis
-      var yAxisTicksText = yAxisG.selectAll("g.tick text")[0];
+      var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
       //Gets width of last Y Axis tick text element
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
       // Move rectangles (bars)
-      rects.attr("x", function(d, i) {
+      rects.attr('x', function(d, i) {
         //if Y Axis title is defined lets make space for Y Axis title by adding the lineheight times 2, to each bar position, and the width of the last, and presumably longest, tick text width
         if(isYAxisTextDefined) {
           return xScale(i) + xAxisRectOffset + yAxisLastTickWidth;
         } else {
           return xScale(i) + lineHeight + yAxisLastTickWidth;
         }
-      }).attr("y", function(d) {
+      }).attr('y', function(d) {
         //If chart text is defined, add the height of the svg chart text and the lineheight to offsett the rects on the y
         return chartTextDefined ? yScale(d.value) + chartTitleTextOffset : yScale(d.value);
-      }).attr("width", xScale.rangeBand())
-          .attr("height", function(d) {
+      }).attr('width', xScale.rangeBand())
+          .attr('height', function(d) {
             return height - yScale(d.value) ;
           });
 
       //Sets the axes titles on resize
       chartText
-          .attr("x", width/2 )
-          .attr("y", lineHeight);
+          .attr('x', width/2 )
+          .attr('y', lineHeight);
 
       xAxisTitle
-          .attr("x", width/2 )
-          .attr("y", h);
+          .attr('x', width/2 )
+          .attr('y', h);
       yAxisTitle
-          .attr("x", height/2)
-          .attr("y", 0);
+          .attr('x', height/2)
+          .attr('y', 0);
 
-      var xAxisGTexts = svg.selectAll("g.x-axis g.tick");
+      var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
 
       //Used for positioning/translating the X axis ticks to be in the middle of each bar
-      xAxisGTexts.attr("transform", function(d, i) {
+      xAxisGTexts.attr('transform', function(d, i) {
         var x;
         var y = chartTextDefined ? chartTitleTextOffset: 0;
         if(isYAxisTextDefined) {
           x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
           y += height;
-          return  "translate (" + x + ", " + y +")";
+          return  'translate (' + x + ', ' + y +')';
         }
         else {
           x =  xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
           y += height;
-          return  "translate (" + x + ", " + y +")";
+          return  'translate (' + x + ', ' + y +')';
         }
       });
 
 
       // Re-locate text value labels
-      texts.attr("x", function(d, i) {
+      texts.attr('x', function(d, i) {
         if(isYAxisTextDefined) {
           //Offset a bt more if the Y Axis text is defined
           return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;}
         else {
           return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
         }
-      }).attr("y", function(d) {
+      }).attr('y', function(d) {
         //Add more room with a ternary if chart text is defined
         return height - lineHeight + (chartTextDefined ? chartTitleTextOffset : 0);
       });
 
       // Hide ticks from readspeakers, the entire rectangle is already labelled
-      xAxisG.selectAll("text").attr("aria-hidden", true);
+      xAxisG.selectAll('text').attr('aria-hidden', true);
     };
   }
 
@@ -235,7 +235,7 @@ H5P.Chart.ExtendedBarChart = (function () {
     }
 
     //add one more step if the last tick value is the same as the max value
-    //if you don't want to add, remove "+1"
+    //if you don't want to add, remove '+1'
     var slicesCount = Math.ceil((val + 1) / step);
 
     return {

--- a/extendedBar.js
+++ b/extendedBar.js
@@ -127,10 +127,10 @@ H5P.Chart.ExtendedBarChart = (function () {
       var xAxisRectOffset = lineHeight * 3;
       var chartTitleTextHeight = svg.select('.chart-title')[0][0].getBoundingClientRect().height;
       var chartTitleTextOffset =  chartTitleTextHeight + lineHeight; // Takes the height of the text element and adds line height, so we always have som space under the title
-      var height = h - xTickSize - (lineHeight) - (chartTextDefined ? chartTitleTextOffset : 0); // Add space for labels below, and also the chart title
+      var height = h - xTickSize - (lineHeight) - (chartTextDefined ? chartTitleTextOffset : 20); // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
       if(isXAxisTextDefined) {
-        height = h - xTickSize - (lineHeight * 2) - (chartTextDefined ? chartTitleTextOffset : 0);
+        height = h - xTickSize - (lineHeight * 2) - (chartTextDefined ? chartTitleTextOffset : 20);
       }
 
       // Update SVG size
@@ -147,7 +147,7 @@ H5P.Chart.ExtendedBarChart = (function () {
       xAxisG.attr('transform', 'translate(0,0)').call(xAxis);
       //A lot of conditional moving here. If Y axis text is defined, we translate 40 px in the X direction. In the Y direction we translate downward the by current chartTitle height and line height
       yAxisG
-          .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
+          .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ',' + (chartTextDefined ? chartTitleTextOffset : 20) + ')');
 
       yAxisG.call(yAxis
           .tickSize(-width, 0, 0)
@@ -168,7 +168,7 @@ H5P.Chart.ExtendedBarChart = (function () {
         }
       }).attr('y', function(d) {
         //If chart text is defined, add the height of the svg chart text and the lineheight to offsett the rects on the y
-        return chartTextDefined ? yScale(d.value) + chartTitleTextOffset : yScale(d.value);
+        return chartTextDefined ? yScale(d.value) + chartTitleTextOffset : 20 + yScale(d.value);
       }).attr('width', xScale.rangeBand())
           .attr('height', function(d) {
             return height - yScale(d.value) ;
@@ -191,7 +191,7 @@ H5P.Chart.ExtendedBarChart = (function () {
       //Used for positioning/translating the X axis ticks to be in the middle of each bar
       xAxisGTexts.attr('transform', function(d, i) {
         var x;
-        var y = chartTextDefined ? chartTitleTextOffset: 0;
+        var y = chartTextDefined ? chartTitleTextOffset: 20;
         if(isYAxisTextDefined) {
           x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
           y += height;
@@ -215,7 +215,7 @@ H5P.Chart.ExtendedBarChart = (function () {
         }
       }).attr('y', function(d) {
         //Add more room with a ternary if chart text is defined
-        return height - lineHeight + (chartTextDefined ? chartTitleTextOffset : 0);
+        return height - lineHeight + (chartTextDefined ? chartTitleTextOffset : 20);
       });
 
       // Hide ticks from screen readers, the entire rectangle is already labelled

--- a/language/.en.json
+++ b/language/.en.json
@@ -8,8 +8,24 @@
         },
         {
           "label": "Bar Chart"
+        },
+        {
+          "value": "extendedBarChart",
+          "label": "Extended Bar Chart"
         }
       ]
+    },
+    {
+      "name": "xAxisText",
+      "type": "text",
+      "label": "X Axis Title",
+      "optional": true
+    },
+    {
+      "name": "yAxisText",
+      "type": "text",
+      "label": "Y Axis Title",
+      "optional": true
     },
     {
       "label": "Data elements",

--- a/language/.en.json
+++ b/language/.en.json
@@ -19,6 +19,43 @@
         ]
       },
       {
+        "label": "Data elements",
+        "entity": "option",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "extendedBarChart",
+                "barChart",
+                "pieChart"
+              ]
+            }
+          ]
+        },
+        "field": {
+          "label": "Data element",
+          "fields": [
+            {
+              "label": "Name"
+            },
+            {
+              "label": "Value"
+            },
+            {
+              "label": "Color"
+            },
+            {
+              "label": "Font Color"
+            }
+          ]
+        }
+      },
+      {
+        "label": "Text read by screen readers defining the figure as a chart."
+      },
+      {
         "label": "Chart Title",
         "description" : "Adds a title on top of chart.",
         "showWhen": {
@@ -113,44 +150,6 @@
           }
         ]
       },
-
-
-      {
-        "label": "Data elements",
-        "entity": "option",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "extendedBarChart",
-                "barChart",
-                "pieChart"
-              ]
-            }
-          ]
-        },
-        "field": {
-          "label": "Data element",
-          "fields": [
-            {
-              "label": "Name"
-            },
-            {
-              "label": "Value"
-            },
-            {
-              "label": "Color"
-            },
-            {
-              "label": "Font Color"
-            }
-          ]
-        }
-      },
-
-
       {
         "label": "Data elements",
         "widget": "showWhen",
@@ -175,9 +174,6 @@
             }
           ]
         }
-      },
-      {
-        "label": "Text read by screen readers defining the figure as a chart."
       }
     ]
   ]

--- a/language/.en.json
+++ b/language/.en.json
@@ -1,6 +1,5 @@
 {
   "semantics": [
-    [
       {
         "label": "Type of chart",
         "options": [
@@ -21,19 +20,6 @@
       {
         "label": "Data elements",
         "entity": "option",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "extendedBarChart",
-                "barChart",
-                "pieChart"
-              ]
-            }
-          ]
-        },
         "field": {
           "label": "Data element",
           "fields": [
@@ -53,68 +39,23 @@
         }
       },
       {
-        "label": "Text read by screen readers defining the figure as a chart."
+        "label": "Text read by screen readers defining the figure as a chart.",
+        "default" : "Chart"
       },
       {
         "label": "Chart Title",
-        "description" : "Adds a title on top of chart.",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "extendedBarChart",
-                "lineChart"
-              ]
-            }
-          ]
-        }
+        "description" : "Adds a title on top of chart."
       },
       {
         "label": "X Axis Title",
-        "description" : "A title in the bottom of the chart to describe the X axis.",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "extendedBarChart",
-                "lineChart"
-              ]
-            }
-          ]
-        }
+        "description" : "A title in the bottom of the chart to describe the X axis."
       },
       {
         "label": "Y Axis Title",
-        "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "extendedBarChart",
-                "lineChart"
-              ]
-            }
-          ]
-        }
+        "description" : "A title on the left-hand side of the chart to describe the Y axis."
       },
       {
         "label": "Override color controls",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "extendedBarChart"
-              ]
-            }
-          ]
-        },
         "fields": [
           {
             "label": "Override the chart color ",
@@ -131,19 +72,7 @@
         ]
       },
       {
-
         "label": "Line color",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "lineChart"
-              ]
-            }
-          ]
-        },
         "fields": [
           {
             "label": "Color of the line in the chart"
@@ -152,17 +81,6 @@
       },
       {
         "label": "Data elements",
-        "widget": "showWhen",
-        "showWhen": {
-          "rules" : [
-            {
-              "field": "graphMode",
-              "equals" : [
-                "lineChart"
-              ]
-            }
-          ]
-        },
         "field": {
           "label": "Data element",
           "fields": [
@@ -176,5 +94,4 @@
         }
       }
     ]
-  ]
 }

--- a/language/.en.json
+++ b/language/.en.json
@@ -16,15 +16,24 @@
       ]
     },
     {
+      "name": "chartText",
+      "type": "text",
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "optional": true
+    },
+    {
       "name": "xAxisText",
       "type": "text",
       "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
       "optional": true
     },
     {
       "name": "yAxisText",
       "type": "text",
       "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
       "optional": true
     },
     {

--- a/language/.en.json
+++ b/language/.en.json
@@ -1,65 +1,184 @@
 {
   "semantics": [
-    {
-      "label": "Type of chart",
-      "options": [
-        {
-          "label": "Pie Chart"
-        },
-        {
-          "label": "Bar Chart"
-        },
-        {
-          "value": "extendedBarChart",
-          "label": "Extended Bar Chart"
-        }
-      ]
-    },
-    {
-      "name": "chartText",
-      "type": "text",
-      "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "optional": true
-    },
-    {
-      "name": "xAxisText",
-      "type": "text",
-      "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "optional": true
-    },
-    {
-      "name": "yAxisText",
-      "type": "text",
-      "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "optional": true
-    },
-    {
-      "label": "Data elements",
-      "entity": "option",
-      "field": {
-        "label": "Data element",
-        "fields": [
+    [
+      {
+        "label": "Type of chart",
+        "options": [
           {
-            "label": "Name"
+            "label": "Pie Chart"
           },
           {
-            "label": "Value"
+            "label": "Bar Chart"
           },
           {
-            "label": "Color"
+            "label": "Extended Bar Chart"
           },
           {
-            "label": "Font Color"
+            "label": "Line Chart"
           }
         ]
+      },
+      {
+        "label": "Chart Title",
+        "description" : "Adds a title on top of chart.",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "extendedBarChart",
+                "lineChart"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "label": "X Axis Title",
+        "description" : "A title in the bottom of the chart to describe the X axis.",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "extendedBarChart",
+                "lineChart"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "label": "Y Axis Title",
+        "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "extendedBarChart",
+                "lineChart"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "label": "Override color controls",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "extendedBarChart"
+              ]
+            }
+          ]
+        },
+        "fields": [
+          {
+            "label": "Override the chart color ",
+            "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+          },
+          {
+            "label": "Override color for chart",
+            "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+          },
+          {
+            "label": "Override  text color for chart",
+            "description": "Defines a new color for all text in bars."
+          }
+        ]
+      },
+      {
+
+        "label": "Line color",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "lineChart"
+              ]
+            }
+          ]
+        },
+        "fields": [
+          {
+            "label": "Color of the line in the chart"
+          }
+        ]
+      },
+
+
+      {
+        "label": "Data elements",
+        "entity": "option",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "extendedBarChart",
+                "barChart",
+                "pieChart"
+              ]
+            }
+          ]
+        },
+        "field": {
+          "label": "Data element",
+          "fields": [
+            {
+              "label": "Name"
+            },
+            {
+              "label": "Value"
+            },
+            {
+              "label": "Color"
+            },
+            {
+              "label": "Font Color"
+            }
+          ]
+        }
+      },
+
+
+      {
+        "label": "Data elements",
+        "widget": "showWhen",
+        "showWhen": {
+          "rules" : [
+            {
+              "field": "graphMode",
+              "equals" : [
+                "lineChart"
+              ]
+            }
+          ]
+        },
+        "field": {
+          "label": "Data element",
+          "fields": [
+            {
+              "label": "X Value"
+            },
+            {
+              "label": "Y Value"
+            }
+          ]
+        }
+      },
+      {
+        "label": "Text read by screen readers defining the figure as a chart."
       }
-    },
-    {
-      "label": "Text read by readspeakers defining the figure as a chart.",
-      "default": "Chart"
-    }
+    ]
   ]
 }

--- a/language/ar.json
+++ b/language/ar.json
@@ -35,6 +35,126 @@
     {
       "label": "قراءة النص بواسطة آلية تحويل النص الى كلام وذلك بتعريف الشكل كمخطط.",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/ar.json
+++ b/language/ar.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "مخطط شريطي"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/bg.json
+++ b/language/bg.json
@@ -35,6 +35,126 @@
     {
       "label": "Текст, прочетен от четци на екранен текст, определящ фигурата като диаграма.",
       "default": "Диаграма"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/bg.json
+++ b/language/bg.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Лентова диаграма"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/bs.json
+++ b/language/bs.json
@@ -8,6 +8,12 @@
         },
         {
           "label":"Stupčaski grafikon"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -33,69 +39,23 @@
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Text read by screen readers defining the figure as a chart.",
       "default": "Chart"
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/bs.json
+++ b/language/bs.json
@@ -35,6 +35,126 @@
     {
       "label": "Text read by readspeakers defining the figure as a chart.",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/ca.json
+++ b/language/ca.json
@@ -35,6 +35,126 @@
     {
       "label": "Text llegit pels altaveus de lectura en què es defineix la figura com a gràfic.",
       "default": "Diagrama"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/ca.json
+++ b/language/ca.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Diagrama de barres"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/cs.json
+++ b/language/cs.json
@@ -35,6 +35,126 @@
     {
       "label": "Text čtený čtecím zařízení definující obrázek jako graf.",
       "default": "Graf"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/cs.json
+++ b/language/cs.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Sloupcový graf"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/de.json
+++ b/language/de.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Balkendiagramm"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/de.json
+++ b/language/de.json
@@ -35,6 +35,126 @@
     {
       "label": "Text, den ein Vorlesewerkzeug vorliest, um die Abbildung als Diagramm auszuweisen (Barrierefreiheit)",
       "default": "Diagramm"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/el.json
+++ b/language/el.json
@@ -35,6 +35,126 @@
     {
       "label": "Κείμενο ακουστικής υποβοήθησης που ορίζει το σχήμα ως γράφημα.",
       "default": "Γράφημα"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/el.json
+++ b/language/el.json
@@ -8,6 +8,12 @@
         },
         {
           "label":"Ραβδόγραμμα"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -35,6 +35,126 @@
     {
       "label": "Texto leido por herramienta de lectura definiendo la figura como un gráfico.",
       "default": "Gráfico"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -8,6 +8,12 @@
         },
         {
           "label":"Gráfico de barras"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/es.json
+++ b/language/es.json
@@ -35,6 +35,126 @@
     {
       "label": "Texto leido por herramientas de lectura que definen la figura como un gráfico.",
       "default": "Gráfico"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/es.json
+++ b/language/es.json
@@ -8,6 +8,12 @@
         },
         {
           "label":"Gráfico de barras"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/et.json
+++ b/language/et.json
@@ -35,6 +35,126 @@
     {
       "label": "Tekstilugeri loetud tekst, mis määratleb pildi arvjoonisena.",
       "default": "Arvjoonis"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/et.json
+++ b/language/et.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Tulpjoonis"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/eu.json
+++ b/language/eu.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Barra-diagrama"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/eu.json
+++ b/language/eu.json
@@ -35,6 +35,126 @@
     {
       "label": "Irakurtzen duen bozgorailuak irudia diagrama bezala definitzen duen testua.",
       "default": "Diagrama"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/fi.json
+++ b/language/fi.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Pylväs"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/fi.json
+++ b/language/fi.json
@@ -35,6 +35,126 @@
     {
       "label": "Ruudunlukijan teksti kaaviolle.",
       "default": "Kaavio"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/fr.json
+++ b/language/fr.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Graphique en barres"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/fr.json
+++ b/language/fr.json
@@ -35,6 +35,126 @@
     {
       "label": "Texte lu par l'orateur (readspeaker) et qui définit la figure comme étant un graphique.",
       "default": "Graphique"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/gl.json
+++ b/language/gl.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Gráfico de barras"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/gl.json
+++ b/language/gl.json
@@ -35,6 +35,126 @@
     {
       "label": "Texto lido polo lector de pantalla definindo a figura como gráfico.",
       "default": "Gráfico"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/he.json
+++ b/language/he.json
@@ -35,6 +35,126 @@
     {
       "label": "תאור המוקרא על ידי קורא־מסך יקריא את הרכיב כגרף.",
       "default": "גרף"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/he.json
+++ b/language/he.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "גרף עמודות"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/it.json
+++ b/language/it.json
@@ -35,6 +35,126 @@
     {
       "label": "Testo letto da un lettore vocale che  descrive la figura come un grafico",
       "default": "Grafico"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/it.json
+++ b/language/it.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Grafico a barre"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/ja.json
+++ b/language/ja.json
@@ -8,6 +8,12 @@
         },
         {
           "label":"棒グラフ"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -33,69 +39,23 @@
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Text read by screen readers defining the figure as a chart.",
       "default": "Chart"
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/ja.json
+++ b/language/ja.json
@@ -35,6 +35,126 @@
     {
       "label": "Text read by readspeakers defining the figure as a chart.",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/km.json
+++ b/language/km.json
@@ -9,6 +9,12 @@
         },
         {
           "label": "Bar Chart"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -34,69 +40,23 @@
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Text read by screen readers defining the figure as a chart.",
       "default": "ក្រាប"
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -113,19 +73,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -134,17 +82,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/km.json
+++ b/language/km.json
@@ -36,6 +36,126 @@
     {
       "label": "Text read by readspeakers defining the figure as a chart.",
       "default": "ក្រាប"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/ko.json
+++ b/language/ko.json
@@ -35,6 +35,126 @@
     {
       "label": "차트를 그림으로 정의하는 자동 읽어주기 기능이 읽는 텍스트",
       "default": "차트"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/ko.json
+++ b/language/ko.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "막대 차트"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/nb.json
+++ b/language/nb.json
@@ -13,15 +13,24 @@
       ]
     },
     {
+      "name": "chartText",
+      "type": "text",
+      "label": "Graftittel",
+      "description" : "Tittelen på grafen, blir lagt til i toppen.",
+      "optional": true
+    },
+    {
       "name": "xAxisText",
       "type": "text",
       "label": "X aksetittel",
+      "description" : "En tittel i bunnen av grafen til å beskrive X aksen.",
       "optional": true
     },
     {
       "name": "yAxisText",
       "type": "text",
       "label": "Y aksetittel",
+      "description" : "En tittel til venstre av grafen til å beskrive Y aksen.",
       "optional": true
     },
     {

--- a/language/nb.json
+++ b/language/nb.json
@@ -10,8 +10,10 @@
           "label": "Søylediagram"
         },
         {
-          "value": "extendedBarChart",
           "label": "Utvidet søylediagram"
+        },
+        {
+          "label": "Linjediagram"
         }
       ]
     },
@@ -35,6 +37,62 @@
       "label": "Y aksetittel",
       "description" : "En tittel til venstre av grafen til å beskrive Y aksen.",
       "optional": true
+    },
+    {
+      "name": "overrideColorGroup",
+      "type": "group",
+      "label": "Overstyr farger",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "name": "overrideChartColorsTick",
+          "type": "boolean",
+          "label": "Overstyr diagramfarge",
+          "description": "Kryss av for å overstyre fargene i diagrammet",
+          "importance": "low",
+          "default": false
+        },
+        {
+          "name": "overrideChartColor",
+          "type": "text",
+          "widget": "colorSelector",
+          "label": "Overstyringsfarge for søyler",
+          "description": "Overstyrer søylefargene med valgt farge",
+          "importance": "low",
+          "default": "#000",
+
+          "optional": true,
+          "spectrum": {
+            "showInput": true,
+            "preferredFormat": "hex"
+          }
+        },
+        {
+          "name": "overrideChartColorText",
+          "type": "text",
+          "widget": "colorSelector",
+          "label": "Overstyringsfarge for tekst i søyler",
+          "description": "Overstyrer fargen i teksten inni søylene",
+          "importance": "low",
+          "default": "#fff",
+
+          "optional": true,
+          "spectrum": {
+            "showInput": true,
+            "preferredFormat": "hex"
+          }
+        }
+      ]
     },
     {
       "label":"Verdier",

--- a/language/nb.json
+++ b/language/nb.json
@@ -18,29 +18,18 @@
       ]
     },
     {
-      "name": "chartText",
-      "type": "text",
       "label": "Graftittel",
-      "description" : "Tittelen på grafen, blir lagt til i toppen.",
-      "optional": true
+      "description" : "Tittelen på grafen, blir lagt til i toppen."
     },
     {
-      "name": "xAxisText",
-      "type": "text",
       "label": "X aksetittel",
-      "description" : "En tittel i bunnen av grafen til å beskrive X aksen.",
-      "optional": true
+      "description" : "En tittel i bunnen av grafen til å beskrive X aksen."
     },
     {
-      "name": "yAxisText",
-      "type": "text",
       "label": "Y aksetittel",
-      "description" : "En tittel til venstre av grafen til å beskrive Y aksen.",
-      "optional": true
+      "description" : "En tittel til venstre av grafen til å beskrive Y aksen."
     },
     {
-      "name": "overrideColorGroup",
-      "type": "group",
       "label": "Overstyr farger",
       "widget": "showWhen",
       "showWhen": {
@@ -55,21 +44,12 @@
       },
       "fields": [
         {
-          "name": "overrideChartColorsTick",
-          "type": "boolean",
           "label": "Overstyr diagramfarge",
-          "description": "Kryss av for å overstyre fargene i diagrammet",
-          "importance": "low",
-          "default": false
+          "description": "Kryss av for å overstyre fargene i diagrammet"
         },
         {
-          "name": "overrideChartColor",
-          "type": "text",
-          "widget": "colorSelector",
           "label": "Overstyringsfarge for søyler",
           "description": "Overstyrer søylefargene med valgt farge",
-          "importance": "low",
-          "default": "#000",
 
           "optional": true,
           "spectrum": {
@@ -78,39 +58,76 @@
           }
         },
         {
-          "name": "overrideChartColorText",
-          "type": "text",
-          "widget": "colorSelector",
           "label": "Overstyringsfarge for tekst i søyler",
-          "description": "Overstyrer fargen i teksten inni søylene",
-          "importance": "low",
-          "default": "#fff",
-
-          "optional": true,
-          "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
-          }
+          "description": "Overstyrer fargen i teksten inni søylene"
         }
       ]
     },
     {
-      "label":"Verdier",
-      "entity":"verdi",
-      "field":{
-        "label":"Verdi",
-        "fields":[
+      "label": "Farge på linje",
+      "widget": "showWhen",
+      "fields": [
+        {
+          "label": "Fargen på linjen i linjediagrammet"
+        }
+      ]
+    },
+    {
+      "label": "Verdier",
+      "entity": "option",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
           {
-            "label":"Navn"
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "barChart",
+              "pieChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Verdi",
+        "fields": [
+          {
+            "label": "Navn"
           },
           {
-            "label":"Verdi"
+            "label": "Verdi"
           },
           {
-            "label":"Bakgrunnsfarge"
+            "label": "Farge"
           },
           {
-            "label":"Tekstfarge"
+            "label": "Tekstfarge"
+          }
+        ]
+      }
+    },
+    {
+      "label": "Verdier",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Verdi",
+        "fields": [
+          {
+            "label": "X Verdi",
+            "importance": "medium"
+          },
+          {
+            "label": "Y Verdi"
           }
         ]
       }

--- a/language/nb.json
+++ b/language/nb.json
@@ -7,8 +7,11 @@
           "label":"Kakediagram"
         },
         {
+          "label": "Søylediagram"
+        },
+        {
           "value": "extendedBarChart",
-          "label": "Utvidet kakediagram"
+          "label": "Utvidet søylediagram"
         }
       ]
     },

--- a/language/nb.json
+++ b/language/nb.json
@@ -20,19 +20,6 @@
     {
       "label": "Verdier",
       "entity": "option",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "barChart",
-              "pieChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Verdi",
         "fields": [
@@ -52,7 +39,7 @@
       }
     },
     {
-      "label": "Tekst lest av readspeakers (som definerer figuren som et diagram).",
+      "label": "Tekst lest av screen readers (som definerer figuren som et diagram).",
       "default": "Diagram"
     },
     {
@@ -69,17 +56,6 @@
     },
     {
       "label": "Overstyr farger",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Overstyr diagramfarge",
@@ -87,13 +63,7 @@
         },
         {
           "label": "Overstyringsfarge for søyler",
-          "description": "Overstyrer søylefargene med valgt farge",
-
-          "optional": true,
-          "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
-          }
+          "description": "Overstyrer søylefargene med valgt farge"
         },
         {
           "label": "Overstyringsfarge for tekst i søyler",
@@ -103,33 +73,19 @@
     },
     {
       "label": "Farge på linje",
-      "widget": "showWhen",
       "fields": [
         {
           "label": "Fargen på linjen i linjediagrammet"
         }
       ]
     },
-
     {
       "label": "Verdier",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Verdi",
         "fields": [
           {
-            "label": "X Verdi",
-            "importance": "medium"
+            "label": "X Verdi"
           },
           {
             "label": "Y Verdi"

--- a/language/nb.json
+++ b/language/nb.json
@@ -7,9 +7,22 @@
           "label":"Kakediagram"
         },
         {
-          "label":"Søylediagram"
+          "value": "extendedBarChart",
+          "label": "Utvidet kakediagram"
         }
       ]
+    },
+    {
+      "name": "xAxisText",
+      "type": "text",
+      "label": "X aksetittel",
+      "optional": true
+    },
+    {
+      "name": "yAxisText",
+      "type": "text",
+      "label": "Y aksetittel",
+      "optional": true
     },
     {
       "label":"Verdier",

--- a/language/nb.json
+++ b/language/nb.json
@@ -18,6 +18,44 @@
       ]
     },
     {
+      "label": "Verdier",
+      "entity": "option",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "barChart",
+              "pieChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Verdi",
+        "fields": [
+          {
+            "label": "Navn"
+          },
+          {
+            "label": "Verdi"
+          },
+          {
+            "label": "Farge"
+          },
+          {
+            "label": "Tekstfarge"
+          }
+        ]
+      }
+    },
+    {
+      "label": "Tekst lest av readspeakers (som definerer figuren som et diagram).",
+      "default": "Diagram"
+    },
+    {
       "label": "Graftittel",
       "description" : "Tittelen på grafen, blir lagt til i toppen."
     },
@@ -72,40 +110,7 @@
         }
       ]
     },
-    {
-      "label": "Verdier",
-      "entity": "option",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "barChart",
-              "pieChart"
-            ]
-          }
-        ]
-      },
-      "field": {
-        "label": "Verdi",
-        "fields": [
-          {
-            "label": "Navn"
-          },
-          {
-            "label": "Verdi"
-          },
-          {
-            "label": "Farge"
-          },
-          {
-            "label": "Tekstfarge"
-          }
-        ]
-      }
-    },
+
     {
       "label": "Verdier",
       "widget": "showWhen",
@@ -131,10 +136,6 @@
           }
         ]
       }
-    },
-    {
-      "label": "Tekst lest av readspeakers (som definerer figuren som et diagram).",
-      "default": "Diagram"
     }
   ]
 }

--- a/language/nl.json
+++ b/language/nl.json
@@ -35,6 +35,126 @@
     {
       "label": "Tekst gelezen door readsprekers die het figuur als een grafiek definiëren.",
       "default": "Grafiek"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/nl.json
+++ b/language/nl.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Staafdiagram"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/nn.json
+++ b/language/nn.json
@@ -7,34 +7,134 @@
           "label":"Kakediagram"
         },
         {
-          "label":"Søylediagram"
+          "label": "Søylediagram"
+        },
+        {
+          "label": "Utvida søylediagram"
+        },
+        {
+          "label": "Linjediagram"
         }
       ]
     },
     {
-      "label":"Verdiar",
-      "entity":"verdi",
-      "field":{
-        "label":"Verdi",
-        "fields":[
+      "label": "Verdiar",
+      "entity": "option",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
           {
-            "label":"Namn"
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "barChart",
+              "pieChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Verdiar",
+        "fields": [
+          {
+            "label": "Namn"
           },
           {
-            "label":"Verdi"
+            "label": "Verdi"
           },
           {
-            "label":"Bakgrunnsfarge"
+            "label": "Farge"
           },
           {
-            "label":"Tekstfarge"
+            "label": "Tekstfarge"
           }
         ]
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Tekst lest av skjermlesar (som definerer figuren som eit diagram).",
       "default": "Diagram"
+    },
+    {
+      "label": "Graftittel",
+      "description" : "Tittelen på grafen, blir lagt til i toppen."
+    },
+    {
+      "label": "X aksetittel",
+      "description" : "Ein tittel i bunnen av grafen til å beskrive X aksen."
+    },
+    {
+      "label": "Y aksetittel",
+      "description" : "Ein tittel til venstre av grafen til å beskrive Y aksen."
+    },
+    {
+      "label": "Overstyr farger",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Overstyr diagramfarge",
+          "description": "Kryss av for å overstyre fargane i diagrammet"
+        },
+        {
+          "label": "Overstyringsfarge for søyler",
+          "description": "Overstyrer søylefargane med valgt farge",
+
+          "optional": true,
+          "spectrum": {
+            "showInput": true,
+            "preferredFormat": "hex"
+          }
+        },
+        {
+          "label": "Overstyringsfarge for tekst i søyler",
+          "description": "Overstyrer fargen i teksten inni søylene"
+        }
+      ]
+    },
+    {
+      "label": "Farge på linje",
+      "widget": "showWhen",
+      "fields": [
+        {
+          "label": "Fargen på linjen i linjediagrammet"
+        }
+      ]
+    },
+    {
+      "label": "Verdiar",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Verdi",
+        "fields": [
+          {
+            "label": "X Verdi",
+            "importance": "medium"
+          },
+          {
+            "label": "Y Verdi"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/nn.json
+++ b/language/nn.json
@@ -20,24 +20,11 @@
     {
       "label": "Verdiar",
       "entity": "option",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "barChart",
-              "pieChart"
-            ]
-          }
-        ]
-      },
       "field": {
-        "label": "Verdiar",
+        "label": "Verdi",
         "fields": [
           {
-            "label": "Namn"
+            "label": "Navn"
           },
           {
             "label": "Verdi"
@@ -52,7 +39,7 @@
       }
     },
     {
-      "label": "Tekst lest av skjermlesar (som definerer figuren som eit diagram).",
+      "label": "Tekst lest av screen readers (som definerer figuren som eit diagram).",
       "default": "Diagram"
     },
     {
@@ -68,18 +55,7 @@
       "description" : "Ein tittel til venstre av grafen til å beskrive Y aksen."
     },
     {
-      "label": "Overstyr farger",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
+      "label": "Overstyr fargar",
       "fields": [
         {
           "label": "Overstyr diagramfarge",
@@ -87,13 +63,7 @@
         },
         {
           "label": "Overstyringsfarge for søyler",
-          "description": "Overstyrer søylefargane med valgt farge",
-
-          "optional": true,
-          "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
-          }
+          "description": "Overstyrer søylefargane med valgt farge"
         },
         {
           "label": "Overstyringsfarge for tekst i søyler",
@@ -103,7 +73,6 @@
     },
     {
       "label": "Farge på linje",
-      "widget": "showWhen",
       "fields": [
         {
           "label": "Fargen på linjen i linjediagrammet"
@@ -112,23 +81,11 @@
     },
     {
       "label": "Verdiar",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Verdi",
         "fields": [
           {
-            "label": "X Verdi",
-            "importance": "medium"
+            "label": "X Verdi"
           },
           {
             "label": "Y Verdi"

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -35,6 +35,126 @@
     {
       "label": "Texto lido por leitores de tela definindo a figura como um gráfico.",
       "default": "Gráfico"
+    },
+    {
+      "label": "Título do gráfico",
+      "description" : "Adiciona um título acima de gráfico.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Título do eixo X",
+      "description" : "Um título sob o gráfico para descrever o eixo X",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Título do eixo X",
+      "description" : "Um título sob o gráfico para descrever o eixo Y",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Substituir cores",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Substituir as cores do gráfico",
+          "description": "Se marcado, as cores selecionadas serão usadas como cor do elemento de dados em todas as barras e textos."
+        },
+        {
+          "label": "Substituir a cor do gráfico",
+          "description": "Define uma nova cor para todas os barras. Substitui as cores individuais nos elementos de dados"
+        },
+        {
+          "label": "Substituir a cor do texto do gráfico",
+          "description": "Define uma nova cor para todos os textos nas barras."
+        }
+      ]
+    },
+    {
+
+      "label": "Cor da linha",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Cor da linha no gráfico"
+        }
+      ]
+    },
+    {
+      "label": "Dados de elementos",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Elemento de dado",
+        "fields": [
+          {
+            "label": "Valor X"
+          },
+          {
+            "label": "Valor Y"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Gráfico de barras"
+        },
+        {
+          "label": "Gráfico de barras aumentado"
+        },
+        {
+          "label": "Gráfico de linha"
         }
       ]
     },

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -18,10 +18,10 @@
       ]
     },
     {
-      "label": "Dados",
+      "label": "Elemento de dados",
       "entity": "option",
       "field": {
-        "label": "Dados",
+        "label": "Elemento de dado",
         "fields": [
           {
             "label": "Nome"
@@ -44,64 +44,18 @@
     },
     {
       "label": "Título do gráfico",
-      "description" : "Adiciona um título acima de gráfico.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adiciona um título acima de gráfico."
     },
     {
       "label": "Título do eixo X",
-      "description" : "Um título sob o gráfico para descrever o eixo X",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Um título sob o gráfico para descrever o eixo X"
     },
     {
       "label": "Título do eixo X",
-      "description" : "Um título sob o gráfico para descrever o eixo Y",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Um título sob o gráfico para descrever o eixo Y"
     },
     {
       "label": "Substituir cores",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Substituir as cores do gráfico",
@@ -118,19 +72,7 @@
       ]
     },
     {
-
       "label": "Cor da linha",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Cor da linha no gráfico"
@@ -139,17 +81,6 @@
     },
     {
       "label": "Dados de elementos",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Elemento de dado",
         "fields": [

--- a/language/pt.json
+++ b/language/pt.json
@@ -35,6 +35,126 @@
     {
       "label": "Texto lido por leitores de ecrã definindo a figura como um gráfico.",
       "default": "Gráfico"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/pt.json
+++ b/language/pt.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Gráfico de barras"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -106,25 +66,13 @@
           "description": "Defines a new color for all bars, replaces the individual colors in data elements"
         },
         {
-          "label": "Override text color for chart",
+          "label": "Override  text color for chart",
           "description": "Defines a new color for all text in bars."
         }
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/ru.json
+++ b/language/ru.json
@@ -35,6 +35,126 @@
     {
       "label": "Текст, обработанный ассистирующими технологиями определяет фигуру как диаграмму.",
       "default": "Таблица, диаграмма"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/ru.json
+++ b/language/ru.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Гистограмма"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/sl.json
+++ b/language/sl.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Stolpični"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/sl.json
+++ b/language/sl.json
@@ -35,6 +35,126 @@
     {
       "label": "Besedilo za opis grafikona za bralnike zaslona",
       "default": "Grafikon"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/sma.json
+++ b/language/sma.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Bar Chart"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -33,69 +39,23 @@
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Text read by screen readers defining the figure as a chart.",
       "default": "Chart"
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/sma.json
+++ b/language/sma.json
@@ -35,6 +35,126 @@
     {
       "label": "Text read by readspeakers defining the figure as a chart.",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/sme.json
+++ b/language/sme.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Bar Chart"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -33,69 +39,23 @@
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Text read by screen readers defining the figure as a chart.",
       "default": "Chart"
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/sme.json
+++ b/language/sme.json
@@ -35,6 +35,126 @@
     {
       "label": "Text read by readspeakers defining the figure as a chart.",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/smj.json
+++ b/language/smj.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Bar Chart"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -33,69 +39,23 @@
       }
     },
     {
-      "label": "Text read by readspeakers defining the figure as a chart.",
+      "label": "Text read by screen readers defining the figure as a chart.",
       "default": "Chart"
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/smj.json
+++ b/language/smj.json
@@ -35,6 +35,126 @@
     {
       "label": "Text read by readspeakers defining the figure as a chart.",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/sv.json
+++ b/language/sv.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "Stapeldiagram"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/sv.json
+++ b/language/sv.json
@@ -35,6 +35,126 @@
     {
       "label": "Text som läses av skärmläsare som definierar figuren som ett diagram.",
       "default": "Diagram"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "直方图"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -35,6 +35,126 @@
     {
       "label": "报读器文本",
       "default": "图表"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "長條圖"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -35,6 +35,126 @@
     {
       "label": "閱讀器導讀文字-將圖形定義為圖表.",
       "default": "圖表"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/zh.json
+++ b/language/zh.json
@@ -35,6 +35,126 @@
     {
       "label": "報讀器文本",
       "default": "Chart"
+    },
+    {
+      "label": "Chart Title",
+      "description" : "Adds a title on top of chart.",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "X Axis Title",
+      "description" : "A title in the bottom of the chart to describe the X axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Y Axis Title",
+      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart",
+              "lineChart"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "Override color controls",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "extendedBarChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Override the chart color ",
+          "description": "If ticked, the colors selected will be used as data element color on all bars and txt."
+        },
+        {
+          "label": "Override color for chart",
+          "description": "Defines a new color for all bars, replaces the individual colors in data elements"
+        },
+        {
+          "label": "Override  text color for chart",
+          "description": "Defines a new color for all text in bars."
+        }
+      ]
+    },
+    {
+
+      "label": "Line color",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "fields": [
+        {
+          "label": "Color of the line in the chart"
+        }
+      ]
+    },
+    {
+      "label": "Data elements",
+      "widget": "showWhen",
+      "showWhen": {
+        "rules" : [
+          {
+            "field": "graphMode",
+            "equals" : [
+              "lineChart"
+            ]
+          }
+        ]
+      },
+      "field": {
+        "label": "Data element",
+        "fields": [
+          {
+            "label": "X Value"
+          },
+          {
+            "label": "Y Value"
+          }
+        ]
+      }
     }
   ]
 }

--- a/language/zh.json
+++ b/language/zh.json
@@ -8,6 +8,12 @@
         },
         {
           "label": "直方圖"
+        },
+        {
+          "label": "Extended Bar Chart"
+        },
+        {
+          "label": "Line Chart"
         }
       ]
     },
@@ -38,64 +44,18 @@
     },
     {
       "label": "Chart Title",
-      "description" : "Adds a title on top of chart.",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "Adds a title on top of chart."
     },
     {
       "label": "X Axis Title",
-      "description" : "A title in the bottom of the chart to describe the X axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title in the bottom of the chart to describe the X axis."
     },
     {
       "label": "Y Axis Title",
-      "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart",
-              "lineChart"
-            ]
-          }
-        ]
-      }
+      "description" : "A title on the left-hand side of the chart to describe the Y axis."
     },
     {
       "label": "Override color controls",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "extendedBarChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Override the chart color ",
@@ -112,19 +72,7 @@
       ]
     },
     {
-
       "label": "Line color",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "fields": [
         {
           "label": "Color of the line in the chart"
@@ -133,17 +81,6 @@
     },
     {
       "label": "Data elements",
-      "widget": "showWhen",
-      "showWhen": {
-        "rules" : [
-          {
-            "field": "graphMode",
-            "equals" : [
-              "lineChart"
-            ]
-          }
-        ]
-      },
       "field": {
         "label": "Data element",
         "fields": [

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "title": "Chart",
+  "title": "NDLA Chart",
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
@@ -7,7 +7,7 @@
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",
-  "machineName": "H5P.Chart",
+  "machineName": "H5P.NDLAChart",
   "coreApi": {
     "majorVersion": 1,
     "minorVersion": 21
@@ -46,7 +46,7 @@
       "majorVersion": 1,
       "minorVersion": 2
     },
-    { "machineName": "H5PEditor.ShowWhen",
+    { "machineName": "H5PEditor.NDLAShowWhen",
       "majorVersion": 1,
       "minorVersion": 0 }
   ]

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 18,
+  "patchVersion": 19,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 23,
+  "patchVersion": 24,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 21,
+  "patchVersion": 22,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -32,6 +32,9 @@
     },
     {
       "path": "bar.js"
+    },
+    {
+      "path": "extendedBar.js"
     }
   ],
   "editorDependencies": [

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 19,
+  "patchVersion": 20,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -35,6 +35,9 @@
     },
     {
       "path": "extendedBar.js"
+    },
+    {
+      "path": "line.js"
     }
   ],
   "editorDependencies": [

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 25,
+  "patchVersion": 26,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 22,
+  "patchVersion": 23,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 20,
+  "patchVersion": 21,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",
@@ -45,6 +45,9 @@
       "machineName": "H5PEditor.ColorSelector",
       "majorVersion": 1,
       "minorVersion": 2
-    }
+    },
+    { "machineName": "H5PEditor.ShowWhen",
+      "majorVersion": 1,
+      "minorVersion": 0 }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create different charts",
   "majorVersion": 1,
   "minorVersion": 2,
-  "patchVersion": 24,
+  "patchVersion": 25,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/line.js
+++ b/line.js
@@ -102,19 +102,30 @@ H5P.Chart.LineChart = (function () {
         .enter()
         .append("path");
     var dots = g.selectAll("circle")
-        .data(dataSet, key)
-        .enter()
-        .append("circle")
-        .attr("r", 5)
-        .style("fill", params.lineColorGroup)
-        .on("mouseover", function(d, i) {
-          d3.select(this).transition().duration(200)
-              .attr("r", 7);
-          g.append("text")
-              .attr("x", function() { return xScale(i) - 2;})
-              .attr("y", function() { return yScale(d.value) - 20;})
-              .text(function() { return d.value;})
-              .attr("id", "text_id");})
+            .data(dataSet, key)
+            .enter()
+            .append("circle")
+            .attr("r", 5)
+            .style("fill", params.lineColorGroup)
+            .on("mouseover", function(d, i) {
+              d3.select(this).transition().duration(200)
+                  .attr("r", 7)
+
+              /*var div = svg.append("div")
+                  .attr("class", "tooltip")
+                  .attr("style", "left:" + (xScale(i) - 2) + "px;" + " top:" + (yScale(d.value) - 20) + "px;")
+
+                  .style("left", function() { return xScale(i) - 2;})
+                  .style("top", function() { return yScale(d.value) - 20;});
+              div.html(d.name + "<br/>"  + d.value);*/
+
+              g.append("text")
+                  .attr("x", function() { return xScale(i) - 2;})
+                  .attr("y", function() { return yScale(d.value) - 20;})
+
+                  .text(function() { return d.value;})
+                  .attr("class", "text-node");
+            })
         .on("mouseout", function(d) {
           // Putting style back to default values
           d3.select(this).transition().duration(200)
@@ -122,9 +133,12 @@ H5P.Chart.LineChart = (function () {
               .style("font-size", 12);
 
           // Deleting extra elements
-          d3.select("#text_id").remove();
+          d3.select(".text-node").remove();
 
-        });
+        }
+        );
+
+
 
     var line = d3.svg.line();
 

--- a/line.js
+++ b/line.js
@@ -6,7 +6,7 @@ H5P.Chart.LineChart = (function () {
    *
    * Notice: LineChart uses its own listOfTypes in h5p-chart/semantics.json, its differentiated through the use of "showWhen"-widget
    * @class
-   * @param {array} params from semantics, contains data set
+   * @param {Object} params from semantics, contains data set
    * @param {H5P.jQuery} $wrapper
    */
   function LineChart(params, $wrapper) {
@@ -211,7 +211,7 @@ H5P.Chart.LineChart = (function () {
           .attr("cy", function(d) { return yScale(d.value); });
 
 
-      // Hide ticks from readspeakers, the entire rectangle is already labelled
+      // Hide ticks from screen readers, the entire rectangle is already labelled
       xAxisG.selectAll('text').attr('aria-hidden', true);
     };
   }

--- a/line.js
+++ b/line.js
@@ -54,7 +54,7 @@ H5P.Chart.LineChart = (function () {
         .attr('class', 'y-axis')
         .attr('aria-label', H5P.t())
 
-    svg.on("mouseleave", function() {
+    svg.on("mouseleavse", function() {
       if(isShowingTooltip) {
         onCircleExit();
       }
@@ -124,8 +124,7 @@ H5P.Chart.LineChart = (function () {
 
         .on("mouseout", function(d) { // Animates exit animation for hover exit
           d3.select(this).transition().duration(200)
-              .attr("r", circeRadius)
-              .style("font-size", 12);
+              .attr("r", circeRadius);
         });
 
     function onCircleEnter(d,i, thisCircle) {
@@ -151,17 +150,22 @@ H5P.Chart.LineChart = (function () {
           .text(function() { return d.value;});
       var textWidth = text[0][0].getBoundingClientRect().width;
       var textHeight = text[0][0].getBoundingClientRect().height;
+      console.log(textHeight)
       rectWidth = rectWidth + textWidth;
+      rectHeight = rectHeight / 2 + textHeight;
 
       rect.attr("width", function() { return rectWidth;})
+      rect.attr("height", function() { return rectHeight;})
           .transition().duration(200)
-      group.attr('transform', 'translate (' + (xScale(i) - (rectWidth / 2)) + ',' + (yScale(d.value) - (rectHeight * 1.5)) + ')');
+      group.attr('transform', 'translate (' + (xScale(i) - (rectWidth / 2)) + ',' + (yScale(d.value) - (rectHeight * 1.33)) + ')');
 
       text
           .attr("x", function() { return (rectWidth - textWidth) / 2  ;})
-          .attr("y", function() { return textHeight ;})
+          .attr("y", function() { return rectHeight/2;})
           .attr("id", "value-" + i)
           .text(function() { return d.value;});
+
+      console.log((rectWidth - textWidth))
       isShowingTooltip = true;
 
     }
@@ -191,7 +195,7 @@ H5P.Chart.LineChart = (function () {
       var xAxisRectOffset = lineHeight * 3;
       //If chart title doesnt exist, we still make an offset
       var chartTitleTextHeight = chartTextDefined ? svg.select('.chart-title')[0][0].getBoundingClientRect().height : 40;
-      var chartTitleTextOffset =  chartTitleTextHeight  + lineHeight; // Takes the height of the text element and adds line height, so we always have som space under the title
+      var chartTitleTextOffset =  chartTitleTextHeight  + lineHeight * 2; // Takes the height of the text element and adds line height, so we always have som space under the title
       var height = h - xTickSize - (lineHeight * 2) - chartTitleTextOffset; // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
       if(isXAxisTextDefined) {

--- a/line.js
+++ b/line.js
@@ -4,6 +4,7 @@ H5P.Chart.LineChart = (function () {
   /**
    * Creates a bar chart from the given data set.
    *
+   * Notice: LineChart uses its own listOfTypes in h5p-chart/semantics.json, its differentiated through the use of "showWhen"-widget
    * @class
    * @param {array} params from semantics, contains data set
    * @param {H5P.jQuery} $wrapper
@@ -76,6 +77,8 @@ H5P.Chart.LineChart = (function () {
         .data(dataSet, key)
         .enter();
 
+
+    //TODO: remove this, not used
     // Create inner rect labels
     var texts = svg.selectAll('text')
         .data([dataSet])
@@ -103,7 +106,25 @@ H5P.Chart.LineChart = (function () {
         .enter()
         .append("circle")
         .attr("r", 5)
-        .style("fill","grey");
+        .style("fill", params.lineColorGroup)
+        .on("mouseover", function(d, i) {
+          d3.select(this).transition().duration(200)
+              .attr("r", 7);
+          g.append("text")
+              .attr("x", function() { return xScale(i) - 2;})
+              .attr("y", function() { return yScale(d.value) - 20;})
+              .text(function() { return d.value;})
+              .attr("id", "text_id");})
+        .on("mouseout", function(d) {
+          // Putting style back to default values
+          d3.select(this).transition().duration(200)
+              .attr("r", 5)
+              .style("font-size", 12);
+
+          // Deleting extra elements
+          d3.select("#text_id").remove();
+
+        });
 
     var line = d3.svg.line();
 
@@ -209,11 +230,13 @@ H5P.Chart.LineChart = (function () {
 
       //apply lines after resize
       path.attr("class", "line-path")
-          .attr("d", line);
+          .attr("d", line)
+          .style("stroke", params.lineColorGroup);
 
       //Move dots according to scale
       dots.attr("cx", function(d,i) { return xScale(i);})
-          .attr("cy", function(d) { return yScale(d.value); });
+          .attr("cy", function(d) { return yScale(d.value); })
+
 
       // Hide ticks from readspeakers, the entire rectangle is already labelled
       xAxisG.selectAll('text').attr('aria-hidden', true);

--- a/line.js
+++ b/line.js
@@ -1,0 +1,252 @@
+/*global d3*/
+H5P.Chart.LineChart = (function () {
+
+  /**
+   * Creates a bar chart from the given data set.
+   *
+   * @class
+   * @param {array} params from semantics, contains data set
+   * @param {H5P.jQuery} $wrapper
+   */
+  function LineChart(params, $wrapper) {
+    var self = this;
+    var dataSet = params.listOfTypes;
+    var defColors = d3.scale.ordinal()
+        .range(['#fbb033', '#2f2f2f', '#FFB6C1', '#B0C4DE', '#D3D3D3', '#20B2AA', '#FAFAD2']);
+    //Lets check if the axes titles are defined, used for setting correct offset for title space in the generated svg
+    var chartTextDefined = !!params.chartText;
+    var isXAxisTextDefined = !!params.xAxisText;
+    var isYAxisTextDefined = !!params.yAxisText;
+
+    // Create scales for bars
+    var xScale = d3.scale.ordinal()
+        .domain(d3.range(dataSet.length));
+    var yScale = d3.scale.linear()
+        .domain([0, d3.max(dataSet, function (d) {
+          return d.value ;
+        })]);
+    var x = d3.time.scale();
+    var y = d3.scale.linear();
+
+    var xAxis = d3.svg.axis()
+        .scale(xScale)
+        .orient('bottom')
+        .tickFormat(function (d) {
+          return dataSet[d % dataSet.length].text;
+        });
+
+    var yAxis = d3.svg.axis()
+        .scale(yScale)
+        .orient('left');
+    // Create SVG element
+    var svg = d3.select($wrapper[0])
+        .append('svg');
+
+    svg.append('desc').html('chart');
+
+    // Create x axis
+    var xAxisG = svg.append('g')
+        .attr('class', 'x-axis');
+
+    var yAxisG = svg.append('g')
+        .attr('class', 'y-axis');
+
+    /**
+     * @private
+     */
+    var key = function (d) {
+      return dataSet.indexOf(d);
+    };
+
+    var chartText = svg.append('text')
+        .style('text-anchor', 'middle')
+        .attr('class', 'chart-title')
+        .text(params.chartText);
+
+    var xAxisTitle = svg.append('text')
+        .style('text-anchor', 'middle')
+        .text(params.xAxisText);
+
+    var yAxisTitle = svg.append('text')
+        .style('transform', 'rotate(90deg)')
+        .text(params.yAxisText);
+
+    // Create inner rect labels
+    var xAxisGTexts = svg.selectAll('x-axis text')
+        .data(dataSet, key)
+        .enter();
+
+    // Create inner rect labels
+    var texts = svg.selectAll('text')
+        .data([dataSet])
+        .enter()
+        .append('text')
+        .text(function(d) {
+          return d.value;
+        })
+        .attr('text-anchor', 'middle')
+        .attr('fill', function (d) {
+          if (d.fontColor !== undefined) {
+            return d.fontColor;
+          }
+          return '000000';
+        })
+        .attr('aria-hidden', true);
+
+    var g = svg.append("g");
+    var path =  g.selectAll("path")
+        .data([dataSet])
+        .enter()
+        .append("path");
+    var dots = g.selectAll("circle")
+        .data(dataSet, key)
+        .enter()
+        .append("circle")
+        .attr("r", 5)
+        .style("fill","grey");
+
+    var line = d3.svg.line();
+
+    /**
+     * Fit the current bar chart to the size of the wrapper.
+     */
+    self.resize = function () {
+
+      // Always scale to available space
+      var style = window.getComputedStyle($wrapper[0]);
+      var width = parseFloat(style.width);
+      var h = parseFloat(style.height);
+      var fontSize = parseFloat(style.fontSize);
+      var lineHeight = (1.25 * fontSize);
+      var xTickSize = (fontSize * 0.125);
+      var xAxisRectOffset = lineHeight * 3;
+      var chartTitleTextHeight = svg.select('.chart-title')[0][0].getBoundingClientRect().height;
+      var chartTitleTextOffset =  chartTitleTextHeight + lineHeight; // Takes the height of the text element and adds line height, so we always have som space under the title
+      var height = h - xTickSize - (lineHeight) - (chartTextDefined ? chartTitleTextOffset : 0); // Add space for labels below, and also the chart title
+      //if xAxisTitle exists, them make room for it by adding more lineheight
+      if(isXAxisTextDefined) {
+        height = h - xTickSize - (lineHeight * 2) - (chartTextDefined ? chartTitleTextOffset : 0);
+      }
+      // Update SVG size
+      svg.attr('width', width)
+          .attr('height', h);
+
+
+      // Update scales
+      xScale.rangeRoundBands([0, width - xAxisRectOffset], 0.05); //In order for the X scale to NOT overlap Y axis ticks, we define and offset, making the X scale start further away from the svg wrapper edge
+      yScale.range([height, 0]); //Unlike in 'bar.js', we have 'flipped' the chart, making origo to be in top left corner of chart. This is due to the nature of the Y axis ticks
+
+      x.range([0, width]);
+      y.range([height, 0]);
+
+      xAxis.tickSize([0]);
+      xAxisG.attr('transform', 'translate(0,0)').call(xAxis);
+      //A lot of conditional moving here. If Y axis text is defined, we translate 40 px in the X direction. In the Y direction we translate downward the by current chartTitle height and line height
+      yAxisG
+          .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
+
+      yAxisG.call(yAxis
+          .tickSize(-width, 0, 0)
+          .ticks(getSmartTicks(d3.max(dataSet).value).count));
+
+      //Gets all text element from the Y Axis
+      var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
+      //Gets width of last Y Axis tick text element
+      var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
+
+      //Sets the axes titles on resize
+      chartText
+          .attr('x', width/2 )
+          .attr('y', lineHeight);
+
+      xAxisTitle
+          .attr('x', width/2 )
+          .attr('y', h);
+      yAxisTitle
+          .attr('x', height/2)
+          .attr('y', 0);
+
+      var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
+
+      //Used for positioning/translating the X axis ticks to be in the middle of each bar
+      xAxisGTexts.attr('transform', function(d, i) {
+        var x;
+        var y = chartTextDefined ? chartTitleTextOffset: 0;
+        if(isYAxisTextDefined) {
+          x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
+          y += height;
+          return  'translate (' + x + ', ' + y +')';
+        }
+        else {
+          x =  xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
+          y += height;
+          return  'translate (' + x + ', ' + y +')';
+        }
+      });
+
+      // Re-locate text value labels
+      texts.attr('x', function(d, i) {
+        if(isYAxisTextDefined) {
+          //Offset a bt more if the Y Axis text is defined
+          return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;}
+        else {
+          return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
+        }
+      }).attr('y', function(d) {
+        //Add more room with a ternary if chart text is defined
+        return height - lineHeight + (chartTextDefined ? chartTitleTextOffset : 0);
+      });
+
+      var firstXaxisTick = xAxisG.select('.tick');
+      var firstXaxisTickXPos = d3.transform(firstXaxisTick.attr("transform")).translate[0];
+      var firstXaxisTickWidth = firstXaxisTick[0][0].getBoundingClientRect().width;
+      console.log(firstXaxisTickWidth);
+      g.attr('transform', 'translate(' + (firstXaxisTickXPos - firstXaxisTickWidth )+ ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
+
+      //Apply line positions after the scales have changed on resize
+      line.x(function(d,i) {return xScale(i);})
+          .y(function(d) { return yScale(d.value); });
+
+      //apply lines after resize
+      path.attr("class", "line-path")
+          .attr("d", line);
+
+      //Move dots according to scale
+      dots.attr("cx", function(d,i) { return xScale(i);})
+          .attr("cy", function(d) { return yScale(d.value); });
+
+      // Hide ticks from readspeakers, the entire rectangle is already labelled
+      xAxisG.selectAll('text').attr('aria-hidden', true);
+    };
+  }
+
+  /**
+   * Calculates number of ticks based on an array of numbers
+   * @param val
+   * @returns {{endPoint: number, count: number}}
+   */
+  function getSmartTicks(val) {
+
+    //base step between nearby two ticks
+    var step = Math.pow(10, val.toString().length - 1);
+
+    //modify steps either: 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000...
+    if (val / step < 2) {
+      step = step / 5;
+    } else if (val / step < 5) {
+      step = step / 2;
+    }
+
+    //add one more step if the last tick value is the same as the max value
+    //if you don't want to add, remove '+1'
+    var slicesCount = Math.ceil((val + 1) / step);
+
+    return {
+      endPoint: slicesCount * step,
+      count: Math.min(10, slicesCount) //show max 10 ticks
+    };
+
+  }
+
+  return LineChart;
+})();

--- a/line.js
+++ b/line.js
@@ -180,10 +180,10 @@ H5P.Chart.LineChart = (function () {
      * Fit the current bar chart to the size of the wrapper.
      */
     self.resize = function () {
-
       // Always scale to available space
       var style = window.getComputedStyle($wrapper[0]);
-      var width = parseFloat(style.width);
+  var horizontalPadding = parseFloat(style.width) / 16;
+      var width = parseFloat(style.width) - horizontalPadding ;
       var h = parseFloat(style.height);
       var fontSize = parseFloat(style.fontSize);
       var lineHeight = (1.25 * fontSize);
@@ -198,7 +198,7 @@ H5P.Chart.LineChart = (function () {
         height = h - xTickSize - (lineHeight * 4) - chartTitleTextOffset;
       }
       // Update SVG size
-      svg.attr('width', width)
+      svg.attr('width', width + horizontalPadding)
           .attr('height', h);
 
 
@@ -250,7 +250,7 @@ H5P.Chart.LineChart = (function () {
 
       });
 
-      var lineXPos = xTranslation + minYAxisGMargin
+      var lineXPos = xTranslation + minYAxisGMargin;
       lineGroup.attr('transform', 'translate(' + lineXPos + ',' + chartTitleTextOffset + ')');
 
       //Apply line positions after the scales have changed on resize

--- a/line.js
+++ b/line.js
@@ -54,7 +54,7 @@ H5P.Chart.LineChart = (function () {
         .attr('class', 'y-axis')
         .attr('aria-label', H5P.t())
 
-    svg.on("mouseleavse", function() {
+    svg.on("mouseleave", function() {
       if(isShowingTooltip) {
         onCircleExit();
       }

--- a/line.js
+++ b/line.js
@@ -77,65 +77,37 @@ H5P.Chart.LineChart = (function () {
         .data(dataSet, key)
         .enter();
 
-
-    //TODO: remove this, not used
-    // Create inner rect labels
-    var texts = svg.selectAll('text')
-        .data([dataSet])
-        .enter()
-        .append('text')
-        .text(function(d) {
-          return d.value;
-        })
-        .attr('text-anchor', 'middle')
-        .attr('fill', function (d) {
-          if (d.fontColor !== undefined) {
-            return d.fontColor;
-          }
-          return '000000';
-        })
-        .attr('aria-hidden', true);
-
-    var g = svg.append("g");
+    var g = svg.append("g"); //Used for creating a container for the
     var path =  g.selectAll("path")
         .data([dataSet])
         .enter()
         .append("path");
     var dots = g.selectAll("circle")
-            .data(dataSet, key)
-            .enter()
-            .append("circle")
-            .attr("r", 5)
-            .style("fill", params.lineColorGroup)
-            .on("mouseover", function(d, i) {
-              d3.select(this).transition().duration(200)
-                  .attr("r", 7)
-
-              /*var div = svg.append("div")
-                  .attr("class", "tooltip")
-                  .attr("style", "left:" + (xScale(i) - 2) + "px;" + " top:" + (yScale(d.value) - 20) + "px;")
-
-                  .style("left", function() { return xScale(i) - 2;})
-                  .style("top", function() { return yScale(d.value) - 20;});
-              div.html(d.name + "<br/>"  + d.value);*/
-
-              g.append("text")
-                  .attr("x", function() { return xScale(i) - 2;})
-                  .attr("y", function() { return yScale(d.value) - 20;})
-
-                  .text(function() { return d.value;})
-                  .attr("class", "text-node");
-            })
-        .on("mouseout", function(d) {
-          // Putting style back to default values
+        .data(dataSet, key)
+        .enter()
+        .append("circle")
+        .attr("r", 5)
+        .style("fill", params.lineColorGroup)
+        .on("mouseover", function(d, i) { // Expands the dot the mouse is hovering and appends a text with
           d3.select(this).transition().duration(200)
-              .attr("r", 5)
-              .style("font-size", 12);
+              .attr("r", 7);
 
-          // Deleting extra elements
-          d3.select(".text-node").remove();
+          g.append("text")
+              .attr("x", function() { return xScale(i) - 2;})
+              .attr("y", function() { return yScale(d.value) - 20;})
 
-        }
+              .text(function() { return d.value;})
+              .attr("class", "text-node");
+        })
+        .on("mouseout", function(d) {
+              // Putting style back to default values
+              d3.select(this).transition().duration(200)
+                  .attr("r", 5)
+                  .style("font-size", 12);
+
+              // Deleting extra elements
+              d3.select(".text-node").remove();
+            }
         );
 
 
@@ -219,23 +191,10 @@ H5P.Chart.LineChart = (function () {
         }
       });
 
-      // Re-locate text value labels
-      texts.attr('x', function(d, i) {
-        if(isYAxisTextDefined) {
-          //Offset a bt more if the Y Axis text is defined
-          return xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;}
-        else {
-          return xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
-        }
-      }).attr('y', function(d) {
-        //Add more room with a ternary if chart text is defined
-        return height - lineHeight + (chartTextDefined ? chartTitleTextOffset : 0);
-      });
 
       var firstXaxisTick = xAxisG.select('.tick');
       var firstXaxisTickXPos = d3.transform(firstXaxisTick.attr("transform")).translate[0];
       var firstXaxisTickWidth = firstXaxisTick[0][0].getBoundingClientRect().width;
-      console.log(firstXaxisTickWidth);
       g.attr('transform', 'translate(' + (firstXaxisTickXPos - firstXaxisTickWidth )+ ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
 
       //Apply line positions after the scales have changed on resize
@@ -249,7 +208,7 @@ H5P.Chart.LineChart = (function () {
 
       //Move dots according to scale
       dots.attr("cx", function(d,i) { return xScale(i);})
-          .attr("cy", function(d) { return yScale(d.value); })
+          .attr("cy", function(d) { return yScale(d.value); });
 
 
       // Hide ticks from readspeakers, the entire rectangle is already labelled

--- a/line.js
+++ b/line.js
@@ -1,7 +1,7 @@
 /*global d3*/
 
 
-H5P.Chart.LineChart = (function () {
+H5P.NDLAChart.LineChart = (function () {
 
   /**
    * Creates a line chart from the given data set.

--- a/line.js
+++ b/line.js
@@ -224,14 +224,13 @@ H5P.Chart.LineChart = (function () {
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
       //A lot of conditional moving here.
-      const xAxisXTranslation = (isYAxisTextDefined ? firstXaxisTickWidth / 2 : 0 );
       var minYAxisGMargin = 20;
-      const yAxisXTranslation = (isYAxisTextDefined ? yAxisLastTickWidth  + minYAxisGMargin : yAxisLastTickWidth * 2 );
+      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth  + minYAxisGMargin : yAxisLastTickWidth * 2 );
       const yTranslation = chartTitleTextOffset;
       // We have to offset the same xTranslation in negative diretion here
-      xAxisG.attr('transform', `translate(${(xAxisXTranslation) * -1}, ${lineHeight/2})`);
+      xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin}, ${lineHeight/2})`);
       yAxisG
-          .attr('transform', `translate(${yAxisXTranslation}, ${yTranslation})`);
+          .attr('transform', `translate(${xTranslation}, ${yTranslation})`);
       //Sets the axes titles on resize
       chartText
           .attr('x', width/2 )
@@ -245,27 +244,21 @@ H5P.Chart.LineChart = (function () {
           .attr('y', 0);
       var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
 
-      //Used for positioning/translating the X axis ticks to be in the middle of each bar
       xAxisGTexts.attr('transform', function(d, i) {
         var x;
         var y = chartTitleTextOffset;
-        if(isYAxisTextDefined) {
-          x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
+          x =  xScale(i);
           y += height;
           return  'translate (' + x + ', ' + y +')';
-        }
-        else {
-          x =  xScale(i) + xScale.rangeBand() / 2  + lineHeight + yAxisLastTickWidth;
-          y += height;
-          return  'translate (' + x + ', ' + y +')';
-        }
+
       });
+
       //Needs to be here, because it's now been placed at its final position
       var firstXaxisTickXPos = d3.transform(firstXaxisTick.attr("transform")).translate[0];
 
       /*To set the position of the lines we first take x pos of first tick, subtract the x translation of the x axis
       and then, since origo of the circle element is top left of irs bounding box, we subtract the half of the circle radius*/
-      var lineXPos = firstXaxisTickXPos - xAxisXTranslation - (circeRadius/2)
+      var lineXPos = firstXaxisTickXPos + firstXaxisTickWidth
       lineGroup.attr('transform', 'translate(' + lineXPos + ',' + chartTitleTextOffset + ')');
 
       //Apply line positions after the scales have changed on resize

--- a/line.js
+++ b/line.js
@@ -203,9 +203,7 @@ H5P.Chart.LineChart = (function () {
         height = h - xTickSize - (lineHeight * 4) - chartTitleTextOffset;
       }
       // Update SVG size
-      svg.attr('width', width + horizontalPadding)
-          .attr('height', h + verticalPadding);
-
+      svg.attr('viewBox', `0 0 ${width + horizontalPadding} ${h + verticalPadding}`);
 
       // Update scales
       xScale.rangeRoundBands([0, width - xAxisRectOffset], 0.05); //In order for the X scale to NOT overlap Y axis ticks, we define and offset, making the X scale start further away from the svg wrapper edge

--- a/line.js
+++ b/line.js
@@ -187,8 +187,9 @@ H5P.Chart.LineChart = (function () {
       // Always scale to available space
       var style = window.getComputedStyle($wrapper[0]);
       var horizontalPadding = parseFloat(style.width) / 16;
+      var verticalPadding = Math.max(parseFloat(style.height) / 16, 20);
       var width = parseFloat(style.width) - horizontalPadding ;
-      var h = parseFloat(style.height);
+      var h = parseFloat(style.height) - verticalPadding;
       var fontSize = parseFloat(style.fontSize);
       var lineHeight = (1.25 * fontSize);
       var xTickSize = (fontSize * 0.125);
@@ -203,7 +204,7 @@ H5P.Chart.LineChart = (function () {
       }
       // Update SVG size
       svg.attr('width', width + horizontalPadding)
-          .attr('height', h);
+          .attr('height', h + verticalPadding);
 
 
       // Update scales
@@ -215,8 +216,7 @@ H5P.Chart.LineChart = (function () {
 
       xAxis.tickSize([0]);
       xAxisG.call(xAxis);
-      var firstXaxisTick = xAxisG.select('.tick');
-      var firstXaxisTickWidth = firstXaxisTick[0][0].getBoundingClientRect().width;
+
       yAxisG.call(yAxis
           .tickSize(-width, 0, 0)
           .ticks(getSmartTicks(d3.max(dataSet).value).count));
@@ -224,9 +224,9 @@ H5P.Chart.LineChart = (function () {
       var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
       //Gets width of last Y Axis tick text element
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
-
       var minYAxisGMargin = 20;
-      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth  + minYAxisGMargin : yAxisLastTickWidth + lineHeight );
+      var yAxisTitleWidth = yAxisTitle[0][0].getBoundingClientRect().width;
+      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth + yAxisTitleWidth + minYAxisGMargin  : yAxisLastTickWidth + lineHeight );
       const yTranslation = chartTitleTextOffset;
 
       xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin}, ${lineHeight/2})`);
@@ -248,9 +248,9 @@ H5P.Chart.LineChart = (function () {
       xAxisGTexts.attr('transform', function(d, i) {
         var x;
         var y = chartTitleTextOffset;
-          x =  xScale(i);
-          y += height;
-          return  'translate (' + x + ', ' + y +')';
+        x =  xScale(i);
+        y += height;
+        return  'translate (' + x + ', ' + y +')';
 
       });
 

--- a/line.js
+++ b/line.js
@@ -182,7 +182,7 @@ H5P.Chart.LineChart = (function () {
     self.resize = function () {
       // Always scale to available space
       var style = window.getComputedStyle($wrapper[0]);
-  var horizontalPadding = parseFloat(style.width) / 16;
+      var horizontalPadding = parseFloat(style.width) / 16;
       var width = parseFloat(style.width) - horizontalPadding ;
       var h = parseFloat(style.height);
       var fontSize = parseFloat(style.fontSize);

--- a/line.js
+++ b/line.js
@@ -129,10 +129,10 @@ H5P.Chart.LineChart = (function () {
       var xAxisRectOffset = lineHeight * 3;
       var chartTitleTextHeight = svg.select('.chart-title')[0][0].getBoundingClientRect().height;
       var chartTitleTextOffset =  chartTitleTextHeight + lineHeight; // Takes the height of the text element and adds line height, so we always have som space under the title
-      var height = h - xTickSize - (lineHeight) - (chartTextDefined ? chartTitleTextOffset : 0); // Add space for labels below, and also the chart title
+      var height = h - xTickSize - (lineHeight) - (chartTextDefined ? chartTitleTextOffset : 40); // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
       if(isXAxisTextDefined) {
-        height = h - xTickSize - (lineHeight * 2) - (chartTextDefined ? chartTitleTextOffset : 0);
+        height = h - xTickSize - (lineHeight * 2) - (chartTextDefined ? chartTitleTextOffset : 40);
       }
       // Update SVG size
       svg.attr('width', width)
@@ -148,19 +148,19 @@ H5P.Chart.LineChart = (function () {
 
       xAxis.tickSize([0]);
       xAxisG.attr('transform', 'translate(0,0)').call(xAxis);
-      //A lot of conditional moving here. If Y axis text is defined, we translate 40 px in the X direction. In the Y direction we translate downward the by current chartTitle height and line height
-      yAxisG
-          .attr('transform', 'translate(' + (isYAxisTextDefined ? 40 : 10) + ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
 
       yAxisG.call(yAxis
           .tickSize(-width, 0, 0)
           .ticks(getSmartTicks(d3.max(dataSet).value).count));
-
       //Gets all text element from the Y Axis
       var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
       //Gets width of last Y Axis tick text element
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
+
+      //A lot of conditional moving here. If Y axis text is defined, we translate 40 px in the X direction. In the Y direction we translate downward the by current chartTitle height and line height
+      yAxisG
+          .attr('transform', 'translate(' + (isYAxisTextDefined ? 15 + yAxisLastTickWidth: 10 + yAxisLastTickWidth) + ',' + (chartTextDefined ? chartTitleTextOffset : 40) + ')');
       //Sets the axes titles on resize
       chartText
           .attr('x', width/2 )
@@ -178,7 +178,7 @@ H5P.Chart.LineChart = (function () {
       //Used for positioning/translating the X axis ticks to be in the middle of each bar
       xAxisGTexts.attr('transform', function(d, i) {
         var x;
-        var y = chartTextDefined ? chartTitleTextOffset: 0;
+        var y = chartTextDefined ? chartTitleTextOffset: 20;
         if(isYAxisTextDefined) {
           x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
           y += height;
@@ -195,7 +195,7 @@ H5P.Chart.LineChart = (function () {
       var firstXaxisTick = xAxisG.select('.tick');
       var firstXaxisTickXPos = d3.transform(firstXaxisTick.attr("transform")).translate[0];
       var firstXaxisTickWidth = firstXaxisTick[0][0].getBoundingClientRect().width;
-      g.attr('transform', 'translate(' + (firstXaxisTickXPos - firstXaxisTickWidth )+ ',' + (chartTextDefined ? chartTitleTextOffset : 0) + ')');
+      g.attr('transform', 'translate(' + (firstXaxisTickXPos - firstXaxisTickWidth )+ ',' + (chartTextDefined ? chartTitleTextOffset : 40) + ')');
 
       //Apply line positions after the scales have changed on resize
       line.x(function(d,i) {return xScale(i);})
@@ -204,8 +204,7 @@ H5P.Chart.LineChart = (function () {
       //apply lines after resize
       path.attr("class", "line-path")
           .attr("d", line)
-          .style("stroke", params.lineColorGroup);
-
+          .style("stroke", params.lineColorGroup ? params.lineColorGroup : "#000000");
       //Move dots according to scale
       dots.attr("cx", function(d,i) { return xScale(i);})
           .attr("cy", function(d) { return yScale(d.value); });

--- a/line.js
+++ b/line.js
@@ -105,7 +105,6 @@ H5P.Chart.LineChart = (function () {
           if(d3.event.keyCode === 9 && isShowingTooltip ){
             onCircleExit(this);
           }
-
           if(d3.event.keyCode === 9 && !isShowingTooltip){
             onCircleEnter(d,i, this);
           }
@@ -121,7 +120,6 @@ H5P.Chart.LineChart = (function () {
           {
             onCircleEnter(d,i, this);
           }
-
         })
 
         .on("mouseout", function(d) { // Animates exit animation for hover exit
@@ -224,7 +222,7 @@ H5P.Chart.LineChart = (function () {
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
       var minYAxisGMargin = 20;
-      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth  + minYAxisGMargin : yAxisLastTickWidth * 2 );
+      const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth  + minYAxisGMargin : yAxisLastTickWidth + lineHeight );
       const yTranslation = chartTitleTextOffset;
 
       xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin}, ${lineHeight/2})`);
@@ -252,11 +250,7 @@ H5P.Chart.LineChart = (function () {
 
       });
 
-      //Needs to be here, because it's now been placed at its final position
-      var firstXaxisTickXPos = d3.transform(firstXaxisTick.attr("transform")).translate[0];
-
-
-      var lineXPos = firstXaxisTickXPos + firstXaxisTickWidth
+      var lineXPos = xTranslation + minYAxisGMargin
       lineGroup.attr('transform', 'translate(' + lineXPos + ',' + chartTitleTextOffset + ')');
 
       //Apply line positions after the scales have changed on resize

--- a/line.js
+++ b/line.js
@@ -181,7 +181,7 @@ H5P.Chart.LineChart = (function () {
       //Used for positioning/translating the X axis ticks to be in the middle of each bar
       xAxisGTexts.attr('transform', function(d, i) {
         var x;
-        var y = chartTextDefined ? chartTitleTextOffset: 20;
+        var y = chartTextDefined ? chartTitleTextOffset: 40;
         if(isYAxisTextDefined) {
           x = xScale(i) + xScale.rangeBand() / 2 + xAxisRectOffset + yAxisLastTickWidth;
           y += height;

--- a/line.js
+++ b/line.js
@@ -223,11 +223,10 @@ H5P.Chart.LineChart = (function () {
       //Gets width of last Y Axis tick text element
       var yAxisLastTickWidth = yAxisTicksText[yAxisTicksText.length-1].getBoundingClientRect().width;
 
-      //A lot of conditional moving here.
       var minYAxisGMargin = 20;
       const xTranslation = (isYAxisTextDefined ? yAxisLastTickWidth  + minYAxisGMargin : yAxisLastTickWidth * 2 );
       const yTranslation = chartTitleTextOffset;
-      // We have to offset the same xTranslation in negative diretion here
+
       xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin}, ${lineHeight/2})`);
       yAxisG
           .attr('transform', `translate(${xTranslation}, ${yTranslation})`);
@@ -256,8 +255,7 @@ H5P.Chart.LineChart = (function () {
       //Needs to be here, because it's now been placed at its final position
       var firstXaxisTickXPos = d3.transform(firstXaxisTick.attr("transform")).translate[0];
 
-      /*To set the position of the lines we first take x pos of first tick, subtract the x translation of the x axis
-      and then, since origo of the circle element is top left of irs bounding box, we subtract the half of the circle radius*/
+
       var lineXPos = firstXaxisTickXPos + firstXaxisTickWidth
       lineGroup.attr('transform', 'translate(' + lineXPos + ',' + chartTitleTextOffset + ')');
 

--- a/line.js
+++ b/line.js
@@ -44,7 +44,7 @@ H5P.Chart.LineChart = (function () {
 
     var svg = d3.select($wrapper[0])
         .append('svg')
-    svg.append('desc').html('chart')
+    svg.append('desc').html('chart');
 
     // Create x axis
     var xAxisG = svg.append('g')
@@ -52,7 +52,7 @@ H5P.Chart.LineChart = (function () {
 
     var yAxisG = svg.append('g')
         .attr('class', 'y-axis')
-        .attr('aria-label', H5P.t())
+        .attr('aria-label', H5P.t());
 
     svg.on("mouseleave", function() {
       if(isShowingTooltip) {

--- a/line.js
+++ b/line.js
@@ -159,8 +159,11 @@ H5P.Chart.LineChart = (function () {
 
 
       //A lot of conditional moving here. If Y axis text is defined, we translate 40 px in the X direction. In the Y direction we translate downward the by current chartTitle height and line height
+      const xTranslation = (isYAxisTextDefined ? 15 + yAxisLastTickWidth : 10 + yAxisLastTickWidth);
+      const yTranslation = (chartTextDefined ? chartTitleTextOffset : 40);
+
       yAxisG
-          .attr('transform', 'translate(' + (isYAxisTextDefined ? 15 + yAxisLastTickWidth: 10 + yAxisLastTickWidth) + ',' + (chartTextDefined ? chartTitleTextOffset : 40) + ')');
+          .attr('transform', `translate(${xTranslation}, ${yTranslation})`);
       //Sets the axes titles on resize
       chartText
           .attr('x', width/2 )

--- a/line.js
+++ b/line.js
@@ -21,41 +21,41 @@ H5P.Chart.LineChart = (function () {
 
     // Create scales for bars
     var xScale = d3.scale.ordinal()
-        .domain(d3.range(dataSet.length));
+      .domain(d3.range(dataSet.length));
     var yScale = d3.scale.linear()
-        .domain([0, d3.max(dataSet, function (d) {
-          return d.value ;
-        })]);
+      .domain([0, d3.max(dataSet, function (d) {
+        return d.value ;
+      })]);
     var x = d3.time.scale();
     var y = d3.scale.linear();
 
     var xAxis = d3.svg.axis()
-        .scale(xScale)
-        .orient('bottom')
-        .tickFormat(function (d) {
-          return dataSet[d % dataSet.length].text;
-        });
+      .scale(xScale)
+      .orient('bottom')
+      .tickFormat(function (d) {
+        return dataSet[d % dataSet.length].text;
+      });
 
     var yAxis = d3.svg.axis()
-        .scale(yScale)
-        .orient('left');
+      .scale(yScale)
+      .orient('left');
     // Create SVG element
     var isShowingTooltip = false;
 
     var svg = d3.select($wrapper[0])
-        .append('svg')
+      .append('svg');
     svg.append('desc').html('chart');
 
     // Create x axis
     var xAxisG = svg.append('g')
-        .attr('class', 'x-axis');
+      .attr('class', 'x-axis');
 
     var yAxisG = svg.append('g')
-        .attr('class', 'y-axis')
-        .attr('aria-label', H5P.t());
+      .attr('class', 'y-axis')
+      .attr('aria-label', H5P.t());
 
-    svg.on("mouseleave", function() {
-      if(isShowingTooltip) {
+    svg.on("mouseleave", function () {
+      if (isShowingTooltip) {
         onCircleExit();
       }
     });
@@ -69,103 +69,125 @@ H5P.Chart.LineChart = (function () {
       return dataSet.indexOf(d);
     };
     var chartText = svg.append('text')
-        .style('text-anchor', 'middle')
-        .attr('class', 'chart-title')
-        .text(params.chartText);
+      .style('text-anchor', 'middle')
+      .attr('class', 'chart-title')
+      .text(params.chartText);
 
     var xAxisTitle = svg.append('text')
-        .style('text-anchor', 'middle')
-        .attr('aria-label', 'X axis title: ' + params.xAxisText)
-        .attr('class', 'axis-title')
-        .text(params.xAxisText);
+      .style('text-anchor', 'middle')
+      .attr('aria-label', 'X axis title: ' + params.xAxisText)
+      .attr('class', 'axis-title')
+      .text(params.xAxisText);
 
     var yAxisTitle = svg.append('text')
-        .style('transform', 'rotate(90deg)')
-        .attr('aria-label', 'Y axis title: ' + params.yAxisText)
-        .attr('class', 'axis-title')
-        .text(params.yAxisText);
+      .style('transform', 'rotate(90deg)')
+      .attr('aria-label', 'Y axis title: ' + params.yAxisText)
+      .attr('class', 'axis-title')
+      .text(params.yAxisText);
 
     var lineGroup = svg.append("g"); //Used for creating a container for the lines
     var path =  lineGroup.selectAll("path")
-        .data([dataSet])
-        .enter()
-        .append("path");
+      .data([dataSet])
+      .enter()
+      .append("path");
     var circeRadius = 7;
     var dots = lineGroup.selectAll("circle")
-        .data(dataSet, key)
-        .enter()
-        .append("circle")
-        .attr("r", circeRadius)
-        .attr("tabindex", 0)
-        .attr('focusable', 'true')
-        .attr("aria-label", (data) => "Y axis: " +  ariaYaxisText + ": " + data.value +
+      .data(dataSet, key)
+      .enter()
+      .append("circle")
+      .attr("r", circeRadius)
+      .attr("tabindex", 0)
+      .attr('focusable', 'true')
+      .attr("aria-label", (data) => "Y axis: " +  ariaYaxisText + ": " + data.value +
             ", X axis: " + ariaXaxisText + ": " + data.text)
-        .style("fill", params.lineColorGroup)
-        .on("keyup", function(d,i) {
-          if(d3.event.keyCode === 9 && isShowingTooltip ){
-            onCircleExit(this);
-          }
-          if(d3.event.keyCode === 9 && !isShowingTooltip){
-            onCircleEnter(d,i, this);
-          }
-        })
+      .style("fill", params.lineColorGroup)
+      .on("keyup", function (d, i) {
+        if (d3.event.keyCode === 9 && isShowingTooltip ) {
+          onCircleExit(this);
+        }
+        if (d3.event.keyCode === 9 && !isShowingTooltip) {
+          onCircleEnter(d, i, this);
+        }
+      })
 
-        .on("mouseover", function(d, i) {
-          d3.select(this).transition().duration(200)
-              .attr("r", circeRadius * 1.25);
-          if(isShowingTooltip) {
-            onCircleExit(this);
-            onCircleEnter(d,i, this);
-          }  else
-          {
-            onCircleEnter(d,i, this);
-          }
-        })
+      .on("mouseover", function (d, i) {
+        d3.select(this).transition().duration(200)
+          .attr("r", circeRadius * 1.25);
+        if (isShowingTooltip) {
+          onCircleExit(this);
+          onCircleEnter(d, i, this);
+        }
+        else {
+          onCircleEnter(d, i, this);
+        }
+      })
 
-        .on("mouseout", function(d) { // Animates exit animation for hover exit
-          d3.select(this).transition().duration(200)
-              .attr("r", circeRadius);
-        });
+      .on("mouseout", function (d) { // Animates exit animation for hover exit
+        d3.select(this).transition().duration(200)
+          .attr("r", circeRadius);
+      });
 
-    function onCircleEnter(d,i, thisCircle) {
+    function onCircleEnter(d, i, thisCircle) {
 
       var rectWidth = 20;
       var rectHeight = 20;
       var group = lineGroup.append("g")
-          .attr("class", "text-group")
+        .attr("class", "text-group");
 
 
       var rect = group.append("rect")
-          .attr("width", function() { return rectWidth;})
-          .attr("height", function() { return rectHeight;})
-          .attr("x", function() { return 0;})
-          .attr("y", function() { return 0;})
+        .attr("width", function () {
+          return rectWidth;
+        })
+        .attr("height", function () {
+          return rectHeight;
+        })
+        .attr("x", function () {
+          return 0;
+        })
+        .attr("y", function () {
+          return 0;
+        })
 
-          .attr("rx", function() { return 2;})
-          .attr("id", "value-" + i)
-          .attr("class", "text-rect");
+        .attr("rx", function () {
+          return 2;
+        })
+        .attr("id", "value-" + i)
+        .attr("class", "text-rect");
 
       var text = group.append("text")
-          .attr("class", "text-node")
-          .text(function() { return d.value;});
+        .attr("class", "text-node")
+        .text(function () {
+          return d.value;
+        });
       var textWidth = text[0][0].getBoundingClientRect().width;
       var textHeight = text[0][0].getBoundingClientRect().height;
-      console.log(textHeight)
+      console.log(textHeight);
       rectWidth = rectWidth + textWidth;
       rectHeight = rectHeight / 2 + textHeight;
 
-      rect.attr("width", function() { return rectWidth;})
-      rect.attr("height", function() { return rectHeight;})
-          .transition().duration(200)
+      rect.attr("width", function () {
+        return rectWidth;
+      });
+      rect.attr("height", function () {
+        return rectHeight;
+      })
+        .transition().duration(200);
       group.attr('transform', 'translate (' + (xScale(i) - (rectWidth / 2)) + ',' + (yScale(d.value) - (rectHeight * 1.33)) + ')');
 
       text
-          .attr("x", function() { return (rectWidth - textWidth) / 2  ;})
-          .attr("y", function() { return rectHeight/2;})
-          .attr("id", "value-" + i)
-          .text(function() { return d.value;});
+        .attr("x", function () {
+          return (rectWidth - textWidth) / 2  ;
+        })
+        .attr("y", function () {
+          return rectHeight/2;
+        })
+        .attr("id", "value-" + i)
+        .text(function () {
+          return d.value;
+        });
 
-      console.log((rectWidth - textWidth))
+      console.log((rectWidth - textWidth));
       isShowingTooltip = true;
 
     }
@@ -199,7 +221,7 @@ H5P.Chart.LineChart = (function () {
       var chartTitleTextOffset =  chartTitleTextHeight  + lineHeight * 2; // Takes the height of the text element and adds line height, so we always have som space under the title
       var height = h - xTickSize - (lineHeight * 2) - chartTitleTextOffset; // Add space for labels below, and also the chart title
       //if xAxisTitle exists, them make room for it by adding more lineheight
-      if(isXAxisTextDefined) {
+      if (isXAxisTextDefined) {
         height = h - xTickSize - (lineHeight * 4) - chartTitleTextOffset;
       }
       // Update SVG size
@@ -216,8 +238,8 @@ H5P.Chart.LineChart = (function () {
       xAxisG.call(xAxis);
 
       yAxisG.call(yAxis
-          .tickSize(-width, 0, 0)
-          .ticks(getSmartTicks(d3.max(dataSet).value).count));
+        .tickSize(-width, 0, 0)
+        .ticks(getSmartTicks(d3.max(dataSet).value).count));
       //Gets all text element from the Y Axis
       var yAxisTicksText = yAxisG.selectAll('g.tick text')[0];
       //Gets width of last Y Axis tick text element
@@ -229,21 +251,21 @@ H5P.Chart.LineChart = (function () {
 
       xAxisG.attr('transform', `translate(${xTranslation + minYAxisGMargin}, ${lineHeight/2})`);
       yAxisG
-          .attr('transform', `translate(${xTranslation}, ${yTranslation})`);
+        .attr('transform', `translate(${xTranslation}, ${yTranslation})`);
       //Sets the axes titles on resize
       chartText
-          .attr('x', width/2 )
-          .attr('y', lineHeight);
+        .attr('x', width/2 )
+        .attr('y', lineHeight);
 
       xAxisTitle
-          .attr('x', width/2 )
-          .attr('y', h-2);
+        .attr('x', width/2 )
+        .attr('y', h-2);
       yAxisTitle
-          .attr('x', height/2)
-          .attr('y', 0);
+        .attr('x', height/2)
+        .attr('y', 0);
       var xAxisGTexts = svg.selectAll('g.x-axis g.tick');
 
-      xAxisGTexts.attr('transform', function(d, i) {
+      xAxisGTexts.attr('transform', function (d, i) {
         var x;
         var y = chartTitleTextOffset;
         x =  xScale(i);
@@ -256,16 +278,24 @@ H5P.Chart.LineChart = (function () {
       lineGroup.attr('transform', 'translate(' + lineXPos + ',' + chartTitleTextOffset + ')');
 
       //Apply line positions after the scales have changed on resize
-      line.x(function(d,i) {return xScale(i);})
-          .y(function(d) { return yScale(d.value); });
+      line.x(function (d, i) {
+        return xScale(i);
+      })
+        .y(function (d) {
+          return yScale(d.value); 
+        });
 
       //apply lines after resize
       path.attr("class", "line-path")
-          .attr("d", line)
-          .style("stroke", params.lineColorGroup);
+        .attr("d", line)
+        .style("stroke", params.lineColorGroup);
       //Move dots according to scale
-      dots.attr("cx", function(d,i) { return xScale(i);})
-          .attr("cy", function(d) { return yScale(d.value); });
+      dots.attr("cx", function (d, i) {
+        return xScale(i);
+      })
+        .attr("cy", function (d) {
+          return yScale(d.value); 
+        });
 
 
       // Hide ticks from screen readers, the entire rectangle is already labelled
@@ -290,7 +320,8 @@ H5P.Chart.LineChart = (function () {
     //modify steps either: 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000...
     if (val / step < 2) {
       step = step / 5;
-    } else if (val / step < 5) {
+    }
+    else if (val / step < 5) {
       step = step / 2;
     }
 

--- a/line.js
+++ b/line.js
@@ -204,7 +204,7 @@ H5P.Chart.LineChart = (function () {
       //apply lines after resize
       path.attr("class", "line-path")
           .attr("d", line)
-          .style("stroke", params.lineColorGroup ? params.lineColorGroup : "#000000");
+          .style("stroke", params.lineColorGroup);
       //Move dots according to scale
       dots.attr("cx", function(d,i) { return xScale(i);})
           .attr("cy", function(d) { return yScale(d.value); });

--- a/pie.js
+++ b/pie.js
@@ -74,8 +74,7 @@ H5P.Chart.PieChart = (function () {
         .innerRadius(0);
 
       // Update positions
-      svg.attr('width', width + 'px')
-        .attr('height', height + 'px');
+      svg.attr('viewBox', `0 0 ${width} ${height}`);
       translater.attr("transform", "translate(" + (width / 2) + "," + (height / 2) + ")");
       paths.attr("d", arc);
       texts.attr("transform", function(d) {

--- a/pie.js
+++ b/pie.js
@@ -1,5 +1,5 @@
 /*global d3*/
-H5P.Chart.PieChart = (function () {
+H5P.NDLAChart.PieChart = (function () {
 
   /**
    * Creates a pie chart from the given data set.

--- a/pie.js
+++ b/pie.js
@@ -26,7 +26,7 @@ H5P.Chart.PieChart = (function () {
 
     var pie = d3.layout.pie()
       .sort(null)
-      .value(function(d) {
+      .value(function (d) {
         return d.value;
       });
 
@@ -36,7 +36,7 @@ H5P.Chart.PieChart = (function () {
       .attr("class", "arc");
 
     var paths = arcs.append("path")
-      .style("fill", function(d) {
+      .style("fill", function (d) {
         if (d.data.color !== undefined) {
           return d.data.color;
         }
@@ -47,7 +47,7 @@ H5P.Chart.PieChart = (function () {
       .attr("class", "text")
       .attr("aria-hidden", true)
       .attr("text-anchor", "middle")
-      .text(function(d, i) {
+      .text(function (d, i) {
         return dataSet[i].text + ': ' + dataSet[i].value;
       })
       .attr("fill", function (d) {
@@ -77,7 +77,7 @@ H5P.Chart.PieChart = (function () {
       svg.attr('viewBox', `0 0 ${width} ${height}`);
       translater.attr("transform", "translate(" + (width / 2) + "," + (height / 2) + ")");
       paths.attr("d", arc);
-      texts.attr("transform", function(d) {
+      texts.attr("transform", function (d) {
         d.innerRadius = 0;
         d.outerRadius = radius - padding;
         return "translate(" + arc.centroid(d) + ")";

--- a/semantics.json
+++ b/semantics.json
@@ -24,13 +24,13 @@
   {
     "name": "xAxisText",
     "type": "text",
-    "label": "X Axis Text",
+    "label": "X Axis Title",
     "optional": true
   },
   {
     "name": "yAxisText",
     "type": "text",
-    "label": "Y Axis Text",
+    "label": "Y Axis Title",
     "optional": true
   },
   {

--- a/semantics.json
+++ b/semantics.json
@@ -103,7 +103,7 @@
         "name": "overrideChartColorsTick",
         "type": "boolean",
         "label": "Override the chart color ",
-        "Described": "If ticked, the color selected will be used as data element color on all bars, and if line chart is selected, define the line color",
+        "description": "If ticked, the colors selected will be used as data element color on all bars and txt.",
         "importance": "low",
         "default": false
       },
@@ -111,7 +111,8 @@
         "name": "overrideChartColor",
         "type": "text",
         "widget": "colorSelector",
-        "label": "overrideColor",
+        "label": "Override color for chart",
+        "description": "Defines a new color for all bars, replaces the individual colors in data elements",
         "importance": "low",
         "default": "#000",
 
@@ -125,7 +126,8 @@
         "name": "overrideChartColorText",
         "type": "text",
         "widget": "colorSelector",
-        "label": "overrideColorText",
+        "label": "Override  text color for chart",
+        "description": "Defines a new color for all text in bars.",
         "importance": "low",
         "default": "#fff",
 

--- a/semantics.json
+++ b/semantics.json
@@ -75,8 +75,13 @@
           "default": "#000",
           "optional": true,
           "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
+            "showPalette": true,
+            "palette": [
+                  ["#1d5cff", "black", "white", "gray"],
+                  ["red", "blue", "yellow", "green"],
+                  ["pink", "purple", "brown", "orange"],
+                  ["lime", "violet", "magenta", "cyan"]
+              ]
           }
         },
         {
@@ -88,8 +93,13 @@
           "default": "#2f2f2f",
           "optional": true,
           "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
+            "showPalette": true,
+            "palette": [
+                  ["#1d5cff", "black", "white", "gray"],
+                  ["red", "blue", "yellow", "green"],
+                  ["pink", "purple", "brown", "orange"],
+                  ["lime", "violet", "magenta", "cyan"]
+              ]
           }
         }
       ]
@@ -196,8 +206,13 @@
 
         "optional": true,
         "spectrum": {
-          "showInput": true,
-          "preferredFormat": "hex"
+          "showPalette": true,
+          "palette": [
+                ["#1d5cff", "black", "white", "gray"],
+                ["red", "blue", "yellow", "green"],
+                ["pink", "purple", "brown", "orange"],
+                ["lime", "violet", "magenta", "cyan"]
+            ]
         }
       },
       {
@@ -211,8 +226,13 @@
 
         "optional": true,
         "spectrum": {
-          "showInput": true,
-          "preferredFormat": "hex"
+          "showPalette": true,
+          "palette": [
+                ["#1d5cff", "black", "white", "gray"],
+                ["red", "blue", "yellow", "green"],
+                ["pink", "purple", "brown", "orange"],
+                ["lime", "violet", "magenta", "cyan"]
+            ]
         }
       }
     ]
@@ -243,8 +263,13 @@
         "importance": "low",
         "optional": true,
         "spectrum": {
-          "showInput": true,
-          "preferredFormat": "hex"
+          "showPalette": true,
+          "palette": [
+                ["#1d5cff", "black", "white", "gray"],
+                ["red", "blue", "yellow", "green"],
+                ["pink", "purple", "brown", "orange"],
+                ["lime", "violet", "magenta", "cyan"]
+            ]
         }
       }
     ]

--- a/semantics.json
+++ b/semantics.json
@@ -16,6 +16,10 @@
       {
         "value": "extendedBarChart",
         "label": "Extended Bar Chart"
+      },
+      {
+        "value": "lineChart",
+        "label": "Line Chart"
       }
     ],
     "default": "pieChart"

--- a/semantics.json
+++ b/semantics.json
@@ -25,6 +25,85 @@
     "default": "pieChart"
   },
   {
+    "name": "listOfTypes",
+    "type": "list",
+    "label": "Data elements",
+    "importance": "high",
+    "entity": "option",
+    "min": 1,
+    "defaultNum": 2,
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "extendedBarChart",
+            "barChart",
+            "pieChart"
+          ]
+        }
+      ]
+    },
+    "field": {
+      "name": "type",
+      "type": "group",
+      "label": "Data element",
+      "importance": "high",
+      "fields": [
+        {
+          "name": "text",
+          "type": "text",
+          "label": "Name",
+          "importance": "medium"
+        },
+        {
+          "name": "value",
+          "type": "number",
+          "label": "Value",
+          "importance": "low",
+          "default": 1,
+          "min": 0.0001,
+          "decimals": 4
+        },
+        {
+          "name": "color",
+          "type": "text",
+          "widget": "colorSelector",
+          "label": "Color",
+          "importance": "low",
+          "default": "#000",
+          "optional": true,
+          "spectrum": {
+            "showInput": true,
+            "preferredFormat": "hex"
+          }
+        },
+        {
+          "name": "fontColor",
+          "type": "text",
+          "widget": "colorSelector",
+          "label": "Font Color",
+          "importance": "low",
+          "default": "#fff",
+          "optional": true,
+          "spectrum": {
+            "showInput": true,
+            "preferredFormat": "hex"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "figureDefinition",
+    "type": "text",
+    "label": "Text read by screen readers defining the figure as a chart.",
+    "importance": "low",
+    "default": "Chart",
+    "common": true
+  },
+  {
     "name": "chartText",
     "type": "text",
     "label": "Chart Title",
@@ -173,78 +252,6 @@
   },
 
 
-  {
-    "name": "listOfTypes",
-    "type": "list",
-    "label": "Data elements",
-    "importance": "high",
-    "entity": "option",
-    "min": 1,
-    "defaultNum": 2,
-    "widget": "showWhen",
-    "showWhen": {
-      "rules" : [
-        {
-          "field": "graphMode",
-          "equals" : [
-            "extendedBarChart",
-            "barChart",
-            "pieChart"
-          ]
-        }
-      ]
-    },
-    "field": {
-      "name": "type",
-      "type": "group",
-      "label": "Data element",
-      "importance": "high",
-      "fields": [
-        {
-          "name": "text",
-          "type": "text",
-          "label": "Name",
-          "importance": "medium"
-        },
-        {
-          "name": "value",
-          "type": "number",
-          "label": "Value",
-          "importance": "low",
-          "default": 1,
-          "min": 0.0001,
-          "decimals": 4
-        },
-        {
-          "name": "color",
-          "type": "text",
-          "widget": "colorSelector",
-          "label": "Color",
-          "importance": "low",
-          "default": "#000",
-          "optional": true,
-          "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
-          }
-        },
-        {
-          "name": "fontColor",
-          "type": "text",
-          "widget": "colorSelector",
-          "label": "Font Color",
-          "importance": "low",
-          "default": "#fff",
-          "optional": true,
-          "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
-          }
-        }
-      ]
-    }
-  },
-
 
   {
     "name": "listOfTypes",
@@ -288,13 +295,5 @@
         }
       ]
     }
-  },
-  {
-    "name": "figureDefinition",
-    "type": "text",
-    "label": "Text read by screen readers defining the figure as a chart.",
-    "importance": "low",
-    "default": "Chart",
-    "common": true
   }
 ]

--- a/semantics.json
+++ b/semantics.json
@@ -25,18 +25,21 @@
     "name": "chartText",
     "type": "text",
     "label": "Chart Title",
+    "description" : "Adds a title on top of chart.",
     "optional": true
   },
   {
     "name": "xAxisText",
     "type": "text",
     "label": "X Axis Title",
+    "description" : "A title in the bottom of the chart to describe the X axis.",
     "optional": true
   },
   {
     "name": "yAxisText",
     "type": "text",
     "label": "Y Axis Title",
+    "description" : "A title on the left-hand side of the chart to describe the Y axis.",
     "optional": true
   },
   {

--- a/semantics.json
+++ b/semantics.json
@@ -32,7 +32,7 @@
     "entity": "option",
     "min": 1,
     "defaultNum": 2,
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "showWhen": {
       "rules" : [
         {
@@ -119,7 +119,7 @@
     "label": "Chart Title",
     "description" : "Adds a title on top of chart.",
     "optional": true,
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "showWhen": {
       "rules" : [
         {
@@ -138,7 +138,7 @@
     "label": "X Axis Title",
     "description" : "A title in the bottom of the chart to describe the X axis.",
     "optional": true,
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "showWhen": {
       "rules" : [
         {
@@ -157,7 +157,7 @@
     "label": "Y Axis Title",
     "description" : "A title on the left-hand side of the chart to describe the Y axis.",
     "optional": true,
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "showWhen": {
       "rules" : [
         {
@@ -175,7 +175,7 @@
     "type": "group",
     "label": "Override color controls",
     "importance": "high",
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "showWhen": {
       "rules" : [
         {
@@ -242,7 +242,7 @@
     "type": "group",
     "label": "Line color",
     "importance": "high",
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "default": "#000000",
     "showWhen": {
       "rules" : [
@@ -285,7 +285,7 @@
     "entity": "option",
     "min": 1,
     "defaultNum": 2,
-    "widget": "showWhen",
+    "widget": "NDLAShowWhen",
     "showWhen": {
       "rules" : [
         {

--- a/semantics.json
+++ b/semantics.json
@@ -12,9 +12,26 @@
       {
         "value": "barChart",
         "label": "Bar Chart"
+      },
+      {
+        "value": "extendedBarChart",
+        "label": "Extended Bar Chart"
       }
     ],
     "default": "pieChart"
+
+  },
+  {
+    "name": "xAxisText",
+    "type": "text",
+    "label": "X Axis Text",
+    "optional": true
+  },
+  {
+    "name": "yAxisText",
+    "type": "text",
+    "label": "Y Axis Text",
+    "optional": true
   },
   {
     "name": "listOfTypes",

--- a/semantics.json
+++ b/semantics.json
@@ -85,7 +85,7 @@
           "widget": "colorSelector",
           "label": "Font Color",
           "importance": "low",
-          "default": "#fff",
+          "default": "#2f2f2f",
           "optional": true,
           "spectrum": {
             "showInput": true,
@@ -207,7 +207,7 @@
         "label": "Override  text color for chart",
         "description": "Defines a new color for all text in bars.",
         "importance": "low",
-        "default": "#fff",
+        "default": "#2f2f2f",
 
         "optional": true,
         "spectrum": {

--- a/semantics.json
+++ b/semantics.json
@@ -30,22 +30,147 @@
     "type": "text",
     "label": "Chart Title",
     "description" : "Adds a title on top of chart.",
-    "optional": true
+    "optional": true,
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "extendedBarChart",
+            "lineChart"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "xAxisText",
     "type": "text",
     "label": "X Axis Title",
     "description" : "A title in the bottom of the chart to describe the X axis.",
-    "optional": true
+    "optional": true,
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "extendedBarChart",
+            "lineChart"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "yAxisText",
     "type": "text",
     "label": "Y Axis Title",
     "description" : "A title on the left-hand side of the chart to describe the Y axis.",
-    "optional": true
+    "optional": true,
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "extendedBarChart"
+          ]
+        }
+      ]
+    }
   },
+  {
+    "name": "overrideColorGroup",
+    "type": "group",
+    "label": "Override color controls",
+    "importance": "high",
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "extendedBarChart"
+          ]
+        }
+      ]
+    },
+    "fields": [
+      {
+        "name": "overrideChartColorsTick",
+        "type": "boolean",
+        "label": "Override the chart color ",
+        "Described": "If ticked, the color selected will be used as data element color on all bars, and if line chart is selected, define the line color",
+        "importance": "low",
+        "default": false
+      },
+      {
+        "name": "overrideChartColor",
+        "type": "text",
+        "widget": "colorSelector",
+        "label": "overrideColor",
+        "importance": "low",
+        "default": "#000",
+
+        "optional": true,
+        "spectrum": {
+          "showInput": true,
+          "preferredFormat": "hex"
+        }
+      },
+      {
+        "name": "overrideChartColorText",
+        "type": "text",
+        "widget": "colorSelector",
+        "label": "overrideColorText",
+        "importance": "low",
+        "default": "#fff",
+
+        "optional": true,
+        "spectrum": {
+          "showInput": true,
+          "preferredFormat": "hex"
+        }
+      }
+    ]
+  },
+  {
+    "name": "lineColorGroup",
+    "type": "group",
+    "label": "Line color",
+    "importance": "high",
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "lineChart"
+          ]
+        }
+      ]
+    },
+    "fields": [
+      {
+        "name": "lineColor",
+        "type": "text",
+        "widget": "colorSelector",
+        "label": "Color of the line in the chart",
+        "importance": "low",
+        "default": "#000",
+
+        "optional": true,
+        "spectrum": {
+          "showInput": true,
+          "preferredFormat": "hex"
+        }
+      }
+    ]
+  },
+
+
   {
     "name": "listOfTypes",
     "type": "list",
@@ -54,6 +179,17 @@
     "entity": "option",
     "min": 1,
     "defaultNum": 2,
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "extendedBarChart"
+          ]
+        }
+      ]
+    },
     "field": {
       "name": "type",
       "type": "group",
@@ -95,6 +231,64 @@
           "label": "Font Color",
           "importance": "low",
           "default": "#fff",
+          "optional": true,
+          "spectrum": {
+            "showInput": true,
+            "preferredFormat": "hex"
+          }
+        }
+      ]
+    }
+  },
+
+
+  {
+    "name": "listOfTypes",
+    "type": "list",
+    "label": "Data elements",
+    "importance": "high",
+    "entity": "option",
+    "min": 1,
+    "defaultNum": 2,
+    "widget": "showWhen",
+    "showWhen": {
+      "rules" : [
+        {
+          "field": "graphMode",
+          "equals" : [
+            "lineChart"
+          ]
+        }
+      ]
+    },
+    "field": {
+      "name": "type",
+      "type": "group",
+      "label": "Data element",
+      "importance": "high",
+      "fields": [
+        {
+          "name": "text",
+          "type": "text",
+          "label": "Name",
+          "importance": "medium"
+        },
+        {
+          "name": "value",
+          "type": "number",
+          "label": "Value",
+          "importance": "low",
+          "default": 1,
+          "min": 0.0001,
+          "decimals": 4
+        },
+        {
+          "name": "fontColor",
+          "type": "text",
+          "widget": "colorSelector",
+          "label": "Font Color",
+          "importance": "low",
+          "default": "#000",
           "optional": true,
           "spectrum": {
             "showInput": true,

--- a/semantics.json
+++ b/semantics.json
@@ -223,6 +223,7 @@
     "label": "Line color",
     "importance": "high",
     "widget": "showWhen",
+    "default": "#000000",
     "showWhen": {
       "rules" : [
         {
@@ -240,8 +241,6 @@
         "widget": "colorSelector",
         "label": "Color of the line in the chart",
         "importance": "low",
-        "default": "#000",
-
         "optional": true,
         "spectrum": {
           "showInput": true,

--- a/semantics.json
+++ b/semantics.json
@@ -23,7 +23,6 @@
       }
     ],
     "default": "pieChart"
-
   },
   {
     "name": "chartText",
@@ -293,7 +292,7 @@
   {
     "name": "figureDefinition",
     "type": "text",
-    "label": "Text read by readspeakers defining the figure as a chart.",
+    "label": "Text read by screen readers defining the figure as a chart.",
     "importance": "low",
     "default": "Chart",
     "common": true

--- a/semantics.json
+++ b/semantics.json
@@ -75,7 +75,8 @@
         {
           "field": "graphMode",
           "equals" : [
-            "extendedBarChart"
+            "extendedBarChart",
+            "lineChart"
           ]
         }
       ]
@@ -185,7 +186,9 @@
         {
           "field": "graphMode",
           "equals" : [
-            "extendedBarChart"
+            "extendedBarChart",
+            "barChart",
+            "pieChart"
           ]
         }
       ]
@@ -270,30 +273,17 @@
         {
           "name": "text",
           "type": "text",
-          "label": "Name",
+          "label": "X Value",
           "importance": "medium"
         },
         {
           "name": "value",
           "type": "number",
-          "label": "Value",
+          "label": "Y Value",
           "importance": "low",
           "default": 1,
           "min": 0.0001,
           "decimals": 4
-        },
-        {
-          "name": "fontColor",
-          "type": "text",
-          "widget": "colorSelector",
-          "label": "Font Color",
-          "importance": "low",
-          "default": "#000",
-          "optional": true,
-          "spectrum": {
-            "showInput": true,
-            "preferredFormat": "hex"
-          }
         }
       ]
     }

--- a/semantics.json
+++ b/semantics.json
@@ -22,6 +22,12 @@
 
   },
   {
+    "name": "chartText",
+    "type": "text",
+    "label": "Chart Title",
+    "optional": true
+  },
+  {
     "name": "xAxisText",
     "type": "text",
     "label": "X Axis Title",

--- a/upgrades.js
+++ b/upgrades.js
@@ -1,6 +1,6 @@
 var H5PUpgrades = H5PUpgrades || {};
 
-H5PUpgrades['H5P.Chart'] = (function () {
+H5PUpgrades['H5P.NDLAChart'] = (function () {
   return {
     1: {
 


### PR DESCRIPTION
This PR adds line and extended bar charts, and is an extension of https://github.com/h5p/h5p-chart/pull/46.

SVG sizes are set with `viewBox` instead of `width` and `height` to make the charts scalable.

See more on https://github.com/h5p/h5p-editor-course-presentation/pull/66